### PR TITLE
Manifest upload/download endpoints

### DIFF
--- a/aserto/directory/model/v3/model.ext.openapi.json
+++ b/aserto/directory/model/v3/model.ext.openapi.json
@@ -1,0 +1,133 @@
+{
+  "openapi": "3.0.3",
+  "paths": {
+    "/api/v3/directory/manifest/{name}/{version}": {
+      "get": {
+        "tags": [
+          "directory"
+        ],
+        "summary": "Get manifest",
+        "description": "Get manifest.",
+        "operationId": "directory.v3.manifest.get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "manifest name (unique, lc-string)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "manifest version (semver notation)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "content": {
+              "application/yaml": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "directory"
+        ],
+        "summary": "Set manifest",
+        "description": "Set manifest.",
+        "operationId": "directory.v3.manifest.set",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "manifest name (unique, lc-string)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "manifest version (semver notation)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Manifest YAML file",
+          "required": true,
+          "content": {
+            "application/yaml": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "content": {
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3SetManifestResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/aserto/directory/model/v3/model.swagger.json
+++ b/aserto/directory/model/v3/model.swagger.json
@@ -15,7 +15,187 @@
   "produces": [
     "application/json"
   ],
-  "paths": {},
+  "paths": {
+    "/api/v3/directory/manifest/{name}/{version}": {
+      "delete": {
+        "summary": "Delete manifest",
+        "description": "Delete manifest.",
+        "operationId": "directory.v3.manifest.delete",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3DeleteManifestResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "description": "manifest name (unique, lc-string)",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "description": "manifest version (semver notation)",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "directory"
+        ],
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ]
+      }
+    },
+    "/api/v3/directory/manifests": {
+      "get": {
+        "summary": "List manifests",
+        "description": "Returns list of stored manifests.",
+        "operationId": "directory.v3.manifests.list",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3ListManifestsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "page.size",
+            "description": "requested page size, valid value between 1-100 rows (default 100)",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "page.token",
+            "description": "pagination start token, default \"\"",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "directory"
+        ],
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ]
+      }
+    },
+    "/api/v3/directory/object_type/{name}": {
+      "get": {
+        "summary": "Get object type",
+        "description": "Returns single object type.",
+        "operationId": "directory.v3.object_types.list",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3GetObjectTypeResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "description": "name of the object type to retrieve",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "directory"
+        ],
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ]
+      }
+    },
+    "/api/v3/directory/object_types": {
+      "get": {
+        "summary": "List all object types",
+        "description": "Returns list of object types.",
+        "operationId": "directory.v3.object_types.list",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3GetObjectTypesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "page.size",
+            "description": "requested page size, valid value between 1-100 rows (default 100)",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "page.token",
+            "description": "pagination start token, default \"\"",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "directory"
+        ],
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ]
+      }
+    }
+  },
   "definitions": {
     "protobufAny": {
       "type": "object",
@@ -69,6 +249,33 @@
         }
       }
     },
+    "v3GetObjectTypeResponse": {
+      "type": "object",
+      "properties": {
+        "result": {
+          "$ref": "#/definitions/v3ObjectType",
+          "title": "object type"
+        }
+      }
+    },
+    "v3GetObjectTypesResponse": {
+      "type": "object",
+      "properties": {
+        "results": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v3ObjectType"
+          },
+          "title": "array of object types"
+        },
+        "page": {
+          "$ref": "#/definitions/v3PaginationResponse",
+          "title": "pagination response",
+          "readOnly": true
+        }
+      }
+    },
     "v3ListManifestsResponse": {
       "type": "object",
       "properties": {
@@ -80,7 +287,7 @@
           },
           "title": "manifests metadata"
         },
-        "next_page": {
+        "page": {
           "$ref": "#/definitions/v3PaginationResponse",
           "title": "pagination response"
         }
@@ -101,6 +308,24 @@
       "required": [
         "name",
         "version"
+      ]
+    },
+    "v3ObjectType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "object type name (unique, lc-string)"
+        },
+        "relation_types": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v3RelationType"
+          }
+        }
+      },
+      "required": [
+        "name"
       ]
     },
     "v3PaginationRequest": {
@@ -128,6 +353,32 @@
         }
       },
       "title": "Pagination response"
+    },
+    "v3RelationType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "object type name (unique, lc-string)"
+        },
+        "permissions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "array of object type permissions"
+        },
+        "unions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "array of other relations types included in this one"
+        }
+      },
+      "required": [
+        "name"
+      ]
     },
     "v3SetManifestResponse": {
       "type": "object",

--- a/aserto/directory/reader/v2/reader.swagger.json
+++ b/aserto/directory/reader/v2/reader.swagger.json
@@ -118,21 +118,13 @@
           "$ref": "#/definitions/v2Object",
           "title": "object instance"
         },
-        "incoming": {
+        "relations": {
           "type": "array",
           "items": {
             "type": "object",
             "$ref": "#/definitions/v2Relation"
           },
-          "title": "incoming object relations of object instance (result.type == incoming.subject.type \u0026\u0026 result.key == incoming.subject.key)"
-        },
-        "outgoing": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/v2Relation"
-          },
-          "title": "outgoing object relations of object instance (result.type == outgoing.object.type \u0026\u0026 result.key == outgoing.object.key)"
+          "title": "object relations"
         }
       }
     },

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -311,15 +311,11 @@ func loadOpenAPI[T any](path string, doc T) error {
 		return fmt.Errorf("unsupported file extension '%s' in [%s]", ext, path)
 	}
 
-	if err := decoder.Decode(&doc); err != nil {
-		return errors.Wrapf(err, "decode openapi v3 file [%s]", path)
-	}
-
-	return nil
+	return decoder.Decode(&doc)
 }
 
 func writeOpenAPI(spec *openapi3.T, path string) error {
-	f, err := os.Create(path)
+	f, err := createFileAndDir(path)
 	if err != nil {
 		return errors.Wrapf(err, "create openapi v3 file [%s]", path)
 	}
@@ -420,7 +416,7 @@ func stripPathsWithTag(paths openapi3.Paths, tag string) {
 	}
 }
 
-func createFile(path string) (*os.File, error) {
+func createFileAndDir(path string) (*os.File, error) {
 	fsutil.EnsureDir(filepath.Dir(path))
 	return os.Create(path)
 }

--- a/publish/directory/openapi.json
+++ b/publish/directory/openapi.json
@@ -763,7 +763,7 @@
     },
     "termsOfService": "https://aserto.com/terms/",
     "title": "Directory",
-    "version": "0.21.5-20230719084454.13.g416d5681-dirty"
+    "version": "x.y.z"
   },
   "openapi": "3.0.3",
   "paths": {
@@ -967,6 +967,131 @@
           }
         ],
         "summary": "Delete manifest",
+        "tags": [
+          "directory"
+        ]
+      },
+      "get": {
+        "description": "Get manifest.",
+        "operationId": "directory.v3.manifest.get",
+        "parameters": [
+          {
+            "description": "manifest name (unique, lc-string)",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "manifest version (semver notation)",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/yaml": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Get manifest",
+        "tags": [
+          "directory"
+        ]
+      },
+      "post": {
+        "description": "Set manifest.",
+        "operationId": "directory.v3.manifest.set",
+        "parameters": [
+          {
+            "description": "manifest name (unique, lc-string)",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "manifest version (semver notation)",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/yaml": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
+            }
+          },
+          "description": "Manifest YAML file",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3SetManifestResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Set manifest",
         "tags": [
           "directory"
         ]

--- a/publish/directory/openapi.json
+++ b/publish/directory/openapi.json
@@ -274,6 +274,29 @@
         },
         "type": "object"
       },
+      "v3GetObjectTypeResponse": {
+        "properties": {
+          "result": {
+            "$ref": "#/components/schemas/v3ObjectType"
+          }
+        },
+        "type": "object"
+      },
+      "v3GetObjectTypesResponse": {
+        "properties": {
+          "page": {
+            "$ref": "#/components/schemas/v3PaginationResponse"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/v3ObjectType"
+            },
+            "title": "array of object types",
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "v3GetObjectsResponse": {
         "properties": {
           "page": {
@@ -407,7 +430,7 @@
             "title": "manifests metadata",
             "type": "array"
           },
-          "next_page": {
+          "page": {
             "$ref": "#/components/schemas/v3PaginationResponse"
           }
         },
@@ -543,6 +566,24 @@
         "title": "Object identifier",
         "type": "object"
       },
+      "v3ObjectType": {
+        "properties": {
+          "name": {
+            "title": "object type name (unique, lc-string)",
+            "type": "string"
+          },
+          "relation_types": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/v3RelationType"
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
       "v3Opcode": {
         "default": "OPCODE_UNKNOWN",
         "enum": [
@@ -630,6 +671,32 @@
         ],
         "type": "object"
       },
+      "v3RelationType": {
+        "properties": {
+          "name": {
+            "title": "object type name (unique, lc-string)",
+            "type": "string"
+          },
+          "permissions": {
+            "items": {
+              "type": "string"
+            },
+            "title": "array of object type permissions",
+            "type": "array"
+          },
+          "unions": {
+            "items": {
+              "type": "string"
+            },
+            "title": "array of other relations types included in this one",
+            "type": "array"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
       "v3SetManifestResponse": {
         "properties": {
           "result": {
@@ -696,7 +763,7 @@
     },
     "termsOfService": "https://aserto.com/terms/",
     "title": "Directory",
-    "version": "0.21.5-20230718202606.12.g6c7f9ba2"
+    "version": "0.21.5-20230719084454.13.g416d5681-dirty"
   },
   "openapi": "3.0.3",
   "paths": {
@@ -842,6 +909,121 @@
           }
         ],
         "summary": "Get graph",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/manifest/{name}/{version}": {
+      "delete": {
+        "description": "Delete manifest.",
+        "operationId": "directory.v3.manifest.delete",
+        "parameters": [
+          {
+            "description": "manifest name (unique, lc-string)",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "manifest version (semver notation)",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3DeleteManifestResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Delete manifest",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/manifests": {
+      "get": {
+        "description": "Returns list of stored manifests.",
+        "operationId": "directory.v3.manifests.list",
+        "parameters": [
+          {
+            "description": "requested page size, valid value between 1-100 rows (default 100)",
+            "in": "query",
+            "name": "page.size",
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "pagination start token, default \"\"",
+            "in": "query",
+            "name": "page.token",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3ListManifestsResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "List manifests",
         "tags": [
           "directory"
         ]
@@ -1038,6 +1220,112 @@
           }
         ],
         "summary": "Get object instance",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/object_type/{name}": {
+      "get": {
+        "description": "Returns single object type.",
+        "operationId": "directory.v3.object_types.list",
+        "parameters": [
+          {
+            "description": "name of the object type to retrieve",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3GetObjectTypeResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Get object type",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/object_types": {
+      "get": {
+        "description": "Returns list of object types.",
+        "operationId": "directory.v3.object_types.list",
+        "parameters": [
+          {
+            "description": "requested page size, valid value between 1-100 rows (default 100)",
+            "in": "query",
+            "name": "page.size",
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "pagination start token, default \"\"",
+            "in": "query",
+            "name": "page.token",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3GetObjectTypesResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "List all object types",
         "tags": [
           "directory"
         ]

--- a/publish/directory/openapi.yaml
+++ b/publish/directory/openapi.yaml
@@ -201,6 +201,21 @@ components:
             $ref: '#/components/schemas/v3Relation'
         result:
           $ref: '#/components/schemas/v3Object'
+    v3GetObjectTypeResponse:
+      type: object
+      properties:
+        result:
+          $ref: '#/components/schemas/v3ObjectType'
+    v3GetObjectTypesResponse:
+      type: object
+      properties:
+        page:
+          $ref: '#/components/schemas/v3PaginationResponse'
+        results:
+          type: array
+          title: array of object types
+          items:
+            $ref: '#/components/schemas/v3ObjectType'
     v3GetObjectsResponse:
       type: object
       properties:
@@ -300,7 +315,7 @@ components:
           title: manifests metadata
           items:
             $ref: '#/components/schemas/v3Metadata'
-        next_page:
+        page:
           $ref: '#/components/schemas/v3PaginationResponse'
     v3Metadata:
       type: object
@@ -400,6 +415,20 @@ components:
         object_type:
           type: string
           title: object type (lc-string)
+    v3ObjectType:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          title: object type name (unique, lc-string)
+        relation_types:
+          type: object
+          additionalProperties:
+            has: null
+            schema:
+              $ref: '#/components/schemas/v3RelationType'
     v3Opcode:
       type: string
       enum:
@@ -466,6 +495,24 @@ components:
           title: last updated timestamp (UTC)
           format: date-time
           readOnly: true
+    v3RelationType:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          title: object type name (unique, lc-string)
+        permissions:
+          type: array
+          title: array of object type permissions
+          items:
+            type: string
+        unions:
+          type: array
+          title: array of other relations types included in this one
+          items:
+            type: string
     v3SetManifestResponse:
       type: object
       properties:
@@ -507,7 +554,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.21.5-20230718202606.12.g6c7f9ba2
+  version: 0.21.5-20230719084454.13.g416d5681-dirty
 paths:
   /api/v3/directory/check/permission:
     post:
@@ -587,6 +634,77 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/v3GetGraphResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/rpcStatus'
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+  /api/v3/directory/manifest/{name}/{version}:
+    delete:
+      tags:
+        - directory
+      summary: Delete manifest
+      description: Delete manifest.
+      operationId: directory.v3.manifest.delete
+      parameters:
+        - name: name
+          in: path
+          description: manifest name (unique, lc-string)
+          required: true
+          schema:
+            type: string
+        - name: version
+          in: path
+          description: manifest version (semver notation)
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/v3DeleteManifestResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/rpcStatus'
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+  /api/v3/directory/manifests:
+    get:
+      tags:
+        - directory
+      summary: List manifests
+      description: Returns list of stored manifests.
+      operationId: directory.v3.manifests.list
+      parameters:
+        - name: page.size
+          in: query
+          description: requested page size, valid value between 1-100 rows (default 100)
+          schema:
+            type: integer
+            format: int32
+        - name: page.token
+          in: query
+          description: pagination start token, default ""
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/v3ListManifestsResponse'
         default:
           description: An unexpected error response.
           content:
@@ -708,6 +826,71 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/v3GetObjectResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/rpcStatus'
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+  /api/v3/directory/object_type/{name}:
+    get:
+      tags:
+        - directory
+      summary: Get object type
+      description: Returns single object type.
+      operationId: directory.v3.object_types.list
+      parameters:
+        - name: name
+          in: path
+          description: name of the object type to retrieve
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/v3GetObjectTypeResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/rpcStatus'
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+  /api/v3/directory/object_types:
+    get:
+      tags:
+        - directory
+      summary: List all object types
+      description: Returns list of object types.
+      operationId: directory.v3.object_types.list
+      parameters:
+        - name: page.size
+          in: query
+          description: requested page size, valid value between 1-100 rows (default 100)
+          schema:
+            type: integer
+            format: int32
+        - name: page.token
+          in: query
+          description: pagination start token, default ""
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/v3GetObjectTypesResponse'
         default:
           description: An unexpected error response.
           content:

--- a/publish/directory/openapi.yaml
+++ b/publish/directory/openapi.yaml
@@ -554,7 +554,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.21.5-20230719084454.13.g416d5681-dirty
+  version: x.y.z
 paths:
   /api/v3/directory/check/permission:
     post:
@@ -670,6 +670,85 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/v3DeleteManifestResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/rpcStatus'
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+    get:
+      tags:
+        - directory
+      summary: Get manifest
+      description: Get manifest.
+      operationId: directory.v3.manifest.get
+      parameters:
+        - name: name
+          in: path
+          description: manifest name (unique, lc-string)
+          required: true
+          schema:
+            type: string
+        - name: version
+          in: path
+          description: manifest version (semver notation)
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/yaml:
+              schema:
+                type: string
+                format: binary
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/rpcStatus'
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+    post:
+      tags:
+        - directory
+      summary: Set manifest
+      description: Set manifest.
+      operationId: directory.v3.manifest.set
+      parameters:
+        - name: name
+          in: path
+          description: manifest name (unique, lc-string)
+          required: true
+          schema:
+            type: string
+        - name: version
+          in: path
+          description: manifest version (semver notation)
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Manifest YAML file
+        required: true
+        content:
+          application/yaml:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/yaml:
+              schema:
+                $ref: '#/components/schemas/v3SetManifestResponse'
         default:
           description: An unexpected error response.
           content:

--- a/service/directory/openapi.json
+++ b/service/directory/openapi.json
@@ -288,6 +288,33 @@
       },
       "type": "object"
     },
+    "v3GetObjectTypeResponse": {
+      "properties": {
+        "result": {
+          "$ref": "#/definitions/v3ObjectType",
+          "title": "object type"
+        }
+      },
+      "type": "object"
+    },
+    "v3GetObjectTypesResponse": {
+      "properties": {
+        "page": {
+          "$ref": "#/definitions/v3PaginationResponse",
+          "readOnly": true,
+          "title": "pagination response"
+        },
+        "results": {
+          "items": {
+            "$ref": "#/definitions/v3ObjectType",
+            "type": "object"
+          },
+          "title": "array of object types",
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "v3GetObjectsResponse": {
       "properties": {
         "page": {
@@ -432,7 +459,7 @@
           "title": "manifests metadata",
           "type": "array"
         },
-        "next_page": {
+        "page": {
           "$ref": "#/definitions/v3PaginationResponse",
           "title": "pagination response"
         }
@@ -569,6 +596,24 @@
       "title": "Object identifier",
       "type": "object"
     },
+    "v3ObjectType": {
+      "properties": {
+        "name": {
+          "title": "object type name (unique, lc-string)",
+          "type": "string"
+        },
+        "relation_types": {
+          "additionalProperties": {
+            "$ref": "#/definitions/v3RelationType"
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
     "v3Opcode": {
       "default": "OPCODE_UNKNOWN",
       "enum": [
@@ -653,6 +698,32 @@
         "relation",
         "subject_type",
         "subject_id"
+      ],
+      "type": "object"
+    },
+    "v3RelationType": {
+      "properties": {
+        "name": {
+          "title": "object type name (unique, lc-string)",
+          "type": "string"
+        },
+        "permissions": {
+          "items": {
+            "type": "string"
+          },
+          "title": "array of object type permissions",
+          "type": "array"
+        },
+        "unions": {
+          "items": {
+            "type": "string"
+          },
+          "title": "array of other relations types included in this one",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name"
       ],
       "type": "object"
     },
@@ -834,6 +905,99 @@
         ]
       }
     },
+    "/api/v3/directory/manifest/{name}/{version}": {
+      "delete": {
+        "description": "Delete manifest.",
+        "operationId": "directory.v3.manifest.delete",
+        "parameters": [
+          {
+            "description": "manifest name (unique, lc-string)",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "manifest version (semver notation)",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3DeleteManifestResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Delete manifest",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/manifests": {
+      "get": {
+        "description": "Returns list of stored manifests.",
+        "operationId": "directory.v3.manifests.list",
+        "parameters": [
+          {
+            "description": "requested page size, valid value between 1-100 rows (default 100)",
+            "format": "int32",
+            "in": "query",
+            "name": "page.size",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "description": "pagination start token, default \"\"",
+            "in": "query",
+            "name": "page.token",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3ListManifestsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "List manifests",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
     "/api/v3/directory/object": {
       "post": {
         "description": "Set object.",
@@ -988,6 +1152,92 @@
           }
         ],
         "summary": "Get object instance",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/object_type/{name}": {
+      "get": {
+        "description": "Returns single object type.",
+        "operationId": "directory.v3.object_types.list",
+        "parameters": [
+          {
+            "description": "name of the object type to retrieve",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3GetObjectTypeResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Get object type",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/object_types": {
+      "get": {
+        "description": "Returns list of object types.",
+        "operationId": "directory.v3.object_types.list",
+        "parameters": [
+          {
+            "description": "requested page size, valid value between 1-100 rows (default 100)",
+            "format": "int32",
+            "in": "query",
+            "name": "page.size",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "description": "pagination start token, default \"\"",
+            "in": "query",
+            "name": "page.token",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3GetObjectTypesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "List all object types",
         "tags": [
           "directory"
         ]


### PR DESCRIPTION
This adds the ability to extend the generated OpenAPI 3.0 spec by providing files containing spec snippets that get merged into the final output.

It is used to define the GET and POST operations on a manifest (`/api/v3/directory/manifest/{name}/{version}`).