### PR TITLE
GetManifest response header and optional version

### DIFF
--- a/aserto/directory/model/v3/model.ext.openapi.json
+++ b/aserto/directory/model/v3/model.ext.openapi.json
@@ -41,14 +41,14 @@
               }
             },
             "headers": {
-              "X-Created-At": {
+              "Aserto-Created-At": {
                 "description": "manifest creation time",
                 "schema": {
                   "type": "string",
                   "format": "date-time"
                 }
               },
-              "X-Updated-At": {
+              "Aserto-Updated-At": {
                 "description": "Last modified date",
                 "schema": {
                   "type": "string",

--- a/aserto/directory/model/v3/model.ext.openapi.json
+++ b/aserto/directory/model/v3/model.ext.openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.3",
   "paths": {
-    "/api/v3/directory/manifest/{name}/{version}": {
+    "/api/v3/directory/manifest/{name}": {
       "get": {
         "tags": [
           "directory"
@@ -21,9 +21,9 @@
           },
           {
             "name": "version",
-            "in": "path",
-            "description": "manifest version (semver notation)",
-            "required": true,
+            "in": "query",
+            "description": "manifest version (semver notation), default to latest",
+            "required": false,
             "schema": {
               "type": "string"
             }
@@ -37,6 +37,28 @@
                 "schema": {
                   "type": "string",
                   "format": "binary"
+                }
+              }
+            },
+            "headers": {
+              "X-Created-At": {
+                "description": "manifest creation time",
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              },
+              "X-Updated-At": {
+                "description": "Last modified date",
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              },
+              "ETag": {
+                "description": "ETag",
+                "schema": {
+                  "type": "string"
                 }
               }
             }


### PR DESCRIPTION
* Make the `version` argument to GetManifest an optional query parameter. If omitted, the latest version of the manifest with the specified name is returned.
* Define response headers to return metadata from GetManifest (created_at, updated_at, etag).