### PR TITLE
Generate spec from v3 definitions

### DIFF
--- a/Depfile
+++ b/Depfile
@@ -5,13 +5,13 @@ go:
     version: "v2.5.0"
   svu:
     importPath: "github.com/caarlos0/svu"
-    version: "latest"
+    version: "v1.11.0"
   buf:
     importPath: "github.com/bufbuild/buf/cmd/buf"
-    version: "v1.17.0"
+    version: "v1.26.1"
   sver:
     importPath: "github.com/aserto-dev/sver/cmd/sver"
-    version: "v1.3.11"
+    version: "v1.3.13"
 bin:
   vault:
     url: "https://releases.hashicorp.com/vault/{{.Version}}/vault_{{.Version}}_{{.OS}}_{{.Arch}}.zip"

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/aserto-dev/openapi-directory
 
-go 1.17
+go 1.19
 
 require github.com/magefile/mage v1.14.0

--- a/go.work
+++ b/go.work
@@ -1,0 +1,7 @@
+go 1.19
+
+use (
+        .
+        ./magefiles
+)
+

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -1,6 +1,6 @@
 module github.com/aserto-dev/openapi-authorizer/magefiles
 
-go 1.17
+go 1.19
 
 require (
 	github.com/aserto-dev/mage-loot v0.8.10

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -6,7 +6,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -108,7 +107,7 @@ func gen(bufImage, fileSources, version string) error {
 func getClientFiles(fileSources string) ([]string, error) {
 	var clientFiles []string
 
-	bufExportDir, err := ioutil.TempDir("", "bufimage")
+	bufExportDir, err := os.MkdirTemp("", "bufimage")
 	if err != nil {
 		return clientFiles, err
 	}

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -184,9 +184,10 @@ func mergeOpenAPI() error {
 		{
 			outfile: "service/directory/openapi.json",
 			subServices: []string{
-				"aserto/directory/common/v2/common.swagger.json",
-				"aserto/directory/reader/v2/reader.swagger.json",
-				"aserto/directory/writer/v2/writer.swagger.json",
+				"aserto/directory/openapi/v3/openapi.swagger.json",
+				"aserto/directory/common/v3/common.swagger.json",
+				"aserto/directory/reader/v3/reader.swagger.json",
+				"aserto/directory/writer/v3/writer.swagger.json",
 			},
 		},
 	}

--- a/publish/directory/openapi.json
+++ b/publish/directory/openapi.json
@@ -39,7 +39,58 @@
         },
         "type": "object"
       },
-      "v2CheckPermissionResponse": {
+      "v3CheckPermissionRequest": {
+        "properties": {
+          "object_id": {
+            "required": [
+              "object_id"
+            ],
+            "title": "object identifier",
+            "type": "string"
+          },
+          "object_type": {
+            "required": [
+              "object_type"
+            ],
+            "title": "object type",
+            "type": "string"
+          },
+          "permission": {
+            "required": [
+              "permission"
+            ],
+            "title": "permission name",
+            "type": "string"
+          },
+          "subject_id": {
+            "required": [
+              "subject_id"
+            ],
+            "title": "subject identifier",
+            "type": "string"
+          },
+          "subject_type": {
+            "required": [
+              "subject_type"
+            ],
+            "title": "subject type",
+            "type": "string"
+          },
+          "trace": {
+            "title": "collect trace information",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "object_type",
+          "object_id",
+          "permission",
+          "subject_type",
+          "subject_id"
+        ],
+        "type": "object"
+      },
+      "v3CheckPermissionResponse": {
         "properties": {
           "check": {
             "title": "check result",
@@ -55,7 +106,58 @@
         },
         "type": "object"
       },
-      "v2CheckRelationResponse": {
+      "v3CheckRelationRequest": {
+        "properties": {
+          "object_id": {
+            "required": [
+              "object_id"
+            ],
+            "title": "object identifier",
+            "type": "string"
+          },
+          "object_type": {
+            "required": [
+              "object_type"
+            ],
+            "title": "object type",
+            "type": "string"
+          },
+          "relation": {
+            "required": [
+              "relation"
+            ],
+            "title": "relation name",
+            "type": "string"
+          },
+          "subject_id": {
+            "required": [
+              "subject_id"
+            ],
+            "title": "subject identifier",
+            "type": "string"
+          },
+          "subject_type": {
+            "required": [
+              "subject_type"
+            ],
+            "title": "subject type",
+            "type": "string"
+          },
+          "trace": {
+            "title": "collect trace information",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "object_type",
+          "object_id",
+          "relation",
+          "subject_type",
+          "subject_id"
+        ],
+        "type": "object"
+      },
+      "v3CheckRelationResponse": {
         "properties": {
           "check": {
             "title": "check result",
@@ -71,7 +173,74 @@
         },
         "type": "object"
       },
-      "v2DeleteObjectResponse": {
+      "v3CheckRequest": {
+        "properties": {
+          "object_id": {
+            "required": [
+              "object_id"
+            ],
+            "title": "object identifier",
+            "type": "string"
+          },
+          "object_type": {
+            "required": [
+              "object_type"
+            ],
+            "title": "object type",
+            "type": "string"
+          },
+          "relation": {
+            "required": [
+              "relation"
+            ],
+            "title": "relation name",
+            "type": "string"
+          },
+          "subject_id": {
+            "required": [
+              "subject_id"
+            ],
+            "title": "subject identifier",
+            "type": "string"
+          },
+          "subject_type": {
+            "required": [
+              "subject_type"
+            ],
+            "title": "subject type",
+            "type": "string"
+          },
+          "trace": {
+            "title": "collect trace information",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "object_type",
+          "object_id",
+          "relation",
+          "subject_type",
+          "subject_id"
+        ],
+        "type": "object"
+      },
+      "v3CheckResponse": {
+        "properties": {
+          "check": {
+            "title": "check result",
+            "type": "boolean"
+          },
+          "trace": {
+            "items": {
+              "type": "string"
+            },
+            "title": "trace information",
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "v3DeleteObjectResponse": {
         "properties": {
           "result": {
             "title": "empty result"
@@ -79,7 +248,7 @@
         },
         "type": "object"
       },
-      "v2DeleteObjectTypeResponse": {
+      "v3DeleteRelationResponse": {
         "properties": {
           "result": {
             "title": "empty result"
@@ -87,35 +256,11 @@
         },
         "type": "object"
       },
-      "v2DeletePermissionResponse": {
-        "properties": {
-          "result": {
-            "title": "empty result"
-          }
-        },
-        "type": "object"
-      },
-      "v2DeleteRelationResponse": {
-        "properties": {
-          "result": {
-            "title": "empty result"
-          }
-        },
-        "type": "object"
-      },
-      "v2DeleteRelationTypeResponse": {
-        "properties": {
-          "result": {
-            "title": "empty result"
-          }
-        },
-        "type": "object"
-      },
-      "v2GetGraphResponse": {
+      "v3GetGraphResponse": {
         "properties": {
           "results": {
             "items": {
-              "$ref": "#/components/schemas/v2ObjectDependency"
+              "$ref": "#/components/schemas/v3ObjectDependency"
             },
             "title": "dependency graph",
             "type": "array"
@@ -123,11 +268,11 @@
         },
         "type": "object"
       },
-      "v2GetObjectManyResponse": {
+      "v3GetObjectManyResponse": {
         "properties": {
           "results": {
             "items": {
-              "$ref": "#/components/schemas/v2Object"
+              "$ref": "#/components/schemas/v3Object"
             },
             "title": "array of object instances",
             "type": "array"
@@ -135,55 +280,32 @@
         },
         "type": "object"
       },
-      "v2GetObjectResponse": {
+      "v3GetObjectResponse": {
         "properties": {
           "page": {
-            "$ref": "#/components/schemas/v2PaginationResponse"
+            "$ref": "#/components/schemas/v3PaginationResponse"
           },
           "relations": {
             "items": {
-              "$ref": "#/components/schemas/v2Relation"
+              "$ref": "#/components/schemas/v3Relation"
             },
             "title": "object relations",
             "type": "array"
           },
           "result": {
-            "$ref": "#/components/schemas/v2Object"
+            "$ref": "#/components/schemas/v3Object"
           }
         },
         "type": "object"
       },
-      "v2GetObjectTypeResponse": {
-        "properties": {
-          "result": {
-            "$ref": "#/components/schemas/v2ObjectType"
-          }
-        },
-        "type": "object"
-      },
-      "v2GetObjectTypesResponse": {
+      "v3GetObjectsResponse": {
         "properties": {
           "page": {
-            "$ref": "#/components/schemas/v2PaginationResponse"
+            "$ref": "#/components/schemas/v3PaginationResponse"
           },
           "results": {
             "items": {
-              "$ref": "#/components/schemas/v2ObjectType"
-            },
-            "title": "array of object types",
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
-      "v2GetObjectsResponse": {
-        "properties": {
-          "page": {
-            "$ref": "#/components/schemas/v2PaginationResponse"
-          },
-          "results": {
-            "items": {
-              "$ref": "#/components/schemas/v2Object"
+              "$ref": "#/components/schemas/v3Object"
             },
             "title": "array of object instances",
             "type": "array"
@@ -191,79 +313,36 @@
         },
         "type": "object"
       },
-      "v2GetPermissionResponse": {
-        "properties": {
-          "result": {
-            "$ref": "#/components/schemas/v2Permission"
-          }
-        },
-        "type": "object"
-      },
-      "v2GetPermissionsResponse": {
-        "properties": {
-          "page": {
-            "$ref": "#/components/schemas/v2PaginationResponse"
-          },
-          "results": {
-            "items": {
-              "$ref": "#/components/schemas/v2Permission"
-            },
-            "title": "array of permissions",
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
-      "v2GetRelationResponse": {
+      "v3GetRelationResponse": {
         "properties": {
           "objects": {
             "additionalProperties": {
-              "$ref": "#/components/schemas/v2Object"
+              "$ref": "#/components/schemas/v3Object"
             },
             "title": "map of materialized relation objects",
             "type": "object"
           },
-          "results": {
-            "items": {
-              "$ref": "#/components/schemas/v2Relation"
-            },
-            "title": "array of relation instances",
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
-      "v2GetRelationTypeResponse": {
-        "properties": {
           "result": {
-            "$ref": "#/components/schemas/v2RelationType"
+            "$ref": "#/components/schemas/v3Relation"
           }
         },
         "type": "object"
       },
-      "v2GetRelationTypesResponse": {
+      "v3GetRelationsResponse": {
         "properties": {
-          "page": {
-            "$ref": "#/components/schemas/v2PaginationResponse"
-          },
-          "results": {
-            "items": {
-              "$ref": "#/components/schemas/v2RelationType"
+          "objects": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/v3Object"
             },
-            "title": "array of relation types",
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
-      "v2GetRelationsResponse": {
-        "properties": {
+            "title": "map of materialized relation objects",
+            "type": "object"
+          },
           "page": {
-            "$ref": "#/components/schemas/v2PaginationResponse"
+            "$ref": "#/components/schemas/v3PaginationResponse"
           },
           "results": {
             "items": {
-              "$ref": "#/components/schemas/v2Relation"
+              "$ref": "#/components/schemas/v3Relation"
             },
             "title": "array of relation instances",
             "type": "array"
@@ -271,10 +350,11 @@
         },
         "type": "object"
       },
-      "v2Object": {
+      "v3Object": {
         "properties": {
           "created_at": {
             "format": "date-time",
+            "readOnly": true,
             "title": "created at timestamp (UTC)",
             "type": "string"
           },
@@ -282,12 +362,15 @@
             "title": "display name object",
             "type": "string"
           },
-          "hash": {
-            "title": "object instance hash",
+          "etag": {
+            "title": "object instance etag",
             "type": "string"
           },
-          "key": {
-            "title": "external object key (cs-string)",
+          "id": {
+            "required": [
+              "id"
+            ],
+            "title": "external object identifier (cs-string, no spaces or tabs)",
             "type": "string"
           },
           "properties": {
@@ -295,128 +378,104 @@
             "type": "object"
           },
           "type": {
+            "required": [
+              "type"
+            ],
             "title": "object type name",
             "type": "string"
           },
           "updated_at": {
             "format": "date-time",
+            "readOnly": true,
             "title": "last updated timestamp (UTC)",
             "type": "string"
           }
         },
+        "required": [
+          "type",
+          "id"
+        ],
         "type": "object"
       },
-      "v2ObjectDependency": {
+      "v3ObjectDependency": {
         "properties": {
           "depth": {
             "format": "int32",
+            "readOnly": true,
             "title": "dependency depth",
             "type": "integer"
           },
           "is_cycle": {
+            "readOnly": true,
             "title": "dependency cycle",
             "type": "boolean"
           },
-          "object_key": {
-            "title": "object search key of source object",
+          "object_id": {
+            "readOnly": true,
+            "title": "object identifier",
             "type": "string"
           },
           "object_type": {
-            "title": "object type name of source object",
+            "readOnly": true,
+            "title": "object type",
             "type": "string"
           },
           "path": {
             "items": {
               "type": "string"
             },
+            "readOnly": true,
             "title": "dependency path",
             "type": "array"
           },
           "relation": {
-            "title": "relation identifier",
+            "readOnly": true,
+            "title": "object relation name",
             "type": "string"
           },
-          "subject_key": {
-            "title": "object search key of target object",
+          "subject_id": {
+            "readOnly": true,
+            "title": "subject identifier",
+            "type": "string"
+          },
+          "subject_relation": {
+            "readOnly": true,
+            "title": "optional subject relation name",
             "type": "string"
           },
           "subject_type": {
-            "title": "object type id of target object",
+            "readOnly": true,
+            "title": "subject type",
             "type": "string"
           }
         },
         "type": "object"
       },
-      "v2ObjectIdentifier": {
+      "v3ObjectIdentifier": {
         "properties": {
-          "key": {
-            "title": "external object key (cs-string)",
+          "object_id": {
+            "required": [
+              "object_id"
+            ],
+            "title": "object identifier (cs-string)",
             "type": "string"
           },
-          "type": {
-            "title": "object type",
+          "object_type": {
+            "required": [
+              "object_type"
+            ],
+            "title": "object type (lc-string)",
             "type": "string"
           }
         },
+        "required": [
+          "object_type",
+          "object_id"
+        ],
         "title": "Object identifier",
         "type": "object"
       },
-      "v2ObjectType": {
-        "properties": {
-          "created_at": {
-            "format": "date-time",
-            "title": "created at timestamp (UTC)",
-            "type": "string"
-          },
-          "display_name": {
-            "title": "object type display name",
-            "type": "string"
-          },
-          "hash": {
-            "title": "object instance hash",
-            "type": "string"
-          },
-          "is_subject": {
-            "title": "object type is a subject (user|group) (default false)",
-            "type": "boolean"
-          },
-          "name": {
-            "title": "object type name (unique, lc-string)",
-            "type": "string"
-          },
-          "ordinal": {
-            "format": "int32",
-            "title": "sort ordinal (default 0)",
-            "type": "integer"
-          },
-          "schema": {
-            "title": "object type schema definition (JSON)",
-            "type": "object"
-          },
-          "status": {
-            "format": "int64",
-            "title": "status flag bitmap (default 0)",
-            "type": "integer"
-          },
-          "updated_at": {
-            "format": "date-time",
-            "title": "last updated timestamp (UTC)",
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "v2ObjectTypeIdentifier": {
-        "properties": {
-          "name": {
-            "title": "object type name (unique, lc-string)",
-            "type": "string"
-          }
-        },
-        "title": "ObjectType identifier",
-        "type": "object"
-      },
-      "v2PaginationRequest": {
+      "v3PaginationRequest": {
         "properties": {
           "size": {
             "format": "int32",
@@ -431,210 +490,128 @@
         "title": "Pagination request",
         "type": "object"
       },
-      "v2PaginationResponse": {
+      "v3PaginationResponse": {
         "properties": {
           "next_token": {
+            "readOnly": true,
             "title": "next page token, when empty there are no more pages to fetch",
             "type": "string"
-          },
-          "result_size": {
-            "format": "int32",
-            "title": "result size of the page returned",
-            "type": "integer"
           }
         },
         "title": "Pagination response",
         "type": "object"
       },
-      "v2Permission": {
+      "v3Relation": {
         "properties": {
           "created_at": {
             "format": "date-time",
+            "readOnly": true,
             "title": "created at timestamp (UTC)",
             "type": "string"
           },
-          "display_name": {
-            "title": "permission display name",
+          "etag": {
+            "title": "object instance etag",
             "type": "string"
           },
-          "hash": {
-            "title": "object instance hash",
-            "type": "string"
-          },
-          "name": {
-            "title": "permission name (unique, cs-string)",
-            "type": "string"
-          },
-          "updated_at": {
-            "format": "date-time",
-            "title": "last updated timestamp (UTC)",
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "v2PermissionIdentifier": {
-        "properties": {
-          "name": {
-            "title": "permission name (unique, cs-string)",
-            "type": "string"
-          }
-        },
-        "title": "Permission identifier",
-        "type": "object"
-      },
-      "v2Relation": {
-        "properties": {
-          "created_at": {
-            "format": "date-time",
-            "title": "created at timestamp (UTC)",
-            "type": "string"
-          },
-          "hash": {
-            "title": "object instance hash",
-            "type": "string"
-          },
-          "object": {
-            "$ref": "#/components/schemas/v2ObjectIdentifier"
-          },
-          "relation": {
-            "title": "relation type name",
-            "type": "string"
-          },
-          "subject": {
-            "$ref": "#/components/schemas/v2ObjectIdentifier"
-          },
-          "updated_at": {
-            "format": "date-time",
-            "title": "last updated timestamp (UTC)",
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "v2RelationIdentifier": {
-        "properties": {
-          "object": {
-            "$ref": "#/components/schemas/v2ObjectIdentifier"
-          },
-          "relation": {
-            "$ref": "#/components/schemas/v2RelationTypeIdentifier"
-          },
-          "subject": {
-            "$ref": "#/components/schemas/v2ObjectIdentifier"
-          }
-        },
-        "title": "Relation identifier",
-        "type": "object"
-      },
-      "v2RelationType": {
-        "properties": {
-          "created_at": {
-            "format": "date-time",
-            "title": "created at timestamp (UTC)",
-            "type": "string"
-          },
-          "display_name": {
-            "title": "relation display name",
-            "type": "string"
-          },
-          "hash": {
-            "title": "object instance hash",
-            "type": "string"
-          },
-          "name": {
-            "title": "relation type name selector",
+          "object_id": {
+            "required": [
+              "object_id"
+            ],
+            "title": "object identifier",
             "type": "string"
           },
           "object_type": {
-            "title": "object type referenced by relation",
+            "required": [
+              "object_type"
+            ],
+            "title": "object type",
             "type": "string"
           },
-          "ordinal": {
-            "format": "int32",
-            "title": "sort ordinal (default 0)",
-            "type": "integer"
+          "relation": {
+            "required": [
+              "relation"
+            ],
+            "title": "object relation name",
+            "type": "string"
           },
-          "permissions": {
-            "items": {
-              "type": "string"
-            },
-            "title": "permissions associated to relation type instance",
-            "type": "array"
+          "subject_id": {
+            "required": [
+              "subject_id"
+            ],
+            "title": "subject identifier",
+            "type": "string"
           },
-          "status": {
-            "format": "int64",
-            "title": "status bitmap (default 0)",
-            "type": "integer"
+          "subject_relation": {
+            "title": "optional subject relation name",
+            "type": "string"
           },
-          "unions": {
-            "items": {
-              "type": "string"
-            },
-            "title": "relations union-ed with relation type instance",
-            "type": "array"
+          "subject_type": {
+            "required": [
+              "subject_type"
+            ],
+            "title": "subject type",
+            "type": "string"
           },
           "updated_at": {
             "format": "date-time",
+            "readOnly": true,
             "title": "last updated timestamp (UTC)",
             "type": "string"
           }
         },
+        "required": [
+          "object_type",
+          "object_id",
+          "relation",
+          "subject_type",
+          "subject_id"
+        ],
         "type": "object"
       },
-      "v2RelationTypeIdentifier": {
+      "v3SetObjectRequest": {
         "properties": {
-          "name": {
-            "title": "relation type name selector",
-            "type": "string"
-          },
-          "object_type": {
-            "title": "object type referenced by relation",
-            "type": "string"
-          }
-        },
-        "title": "RelationType identifier",
-        "type": "object"
-      },
-      "v2SetObjectResponse": {
-        "properties": {
-          "result": {
-            "$ref": "#/components/schemas/v2Object"
+          "object": {
+            "$ref": "#/components/schemas/v3Object"
           }
         },
         "type": "object"
       },
-      "v2SetObjectTypeResponse": {
+      "v3SetObjectResponse": {
         "properties": {
           "result": {
-            "$ref": "#/components/schemas/v2ObjectType"
+            "$ref": "#/components/schemas/v3Object"
           }
         },
         "type": "object"
       },
-      "v2SetPermissionResponse": {
+      "v3SetRelationRequest": {
         "properties": {
-          "result": {
-            "$ref": "#/components/schemas/v2Permission"
+          "relation": {
+            "$ref": "#/components/schemas/v3Relation"
           }
         },
         "type": "object"
       },
-      "v2SetRelationResponse": {
+      "v3SetRelationResponse": {
         "properties": {
           "result": {
-            "$ref": "#/components/schemas/v2Relation"
+            "$ref": "#/components/schemas/v3Relation"
           }
         },
         "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "DirectoryAPIKey": {
+        "in": "header",
+        "name": "authorization",
+        "type": "apiKey"
       },
-      "v2SetRelationTypeResponse": {
-        "properties": {
-          "result": {
-            "$ref": "#/components/schemas/v2RelationType"
-          }
-        },
-        "type": "object"
+      "TenantID": {
+        "description": "Aserto Tenant ID",
+        "in": "header",
+        "name": "aserto-tenant-id",
+        "type": "apiKey"
       }
     }
   },
@@ -658,7 +635,880 @@
     "version": "v0.30.0"
   },
   "openapi": "3.0.3",
-  "paths": null,
+  "paths": {
+    "/api/v3/directory/check": {
+      "post": {
+        "description": "Returns check outcome.",
+        "operationId": "directory.v3.check",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v3CheckRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3CheckResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Check",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/check/permission": {
+      "post": {
+        "description": "Returns check permission outcome.",
+        "operationId": "directory.v3.check.permission",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v3CheckPermissionRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3CheckPermissionResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Check permission",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/check/relation": {
+      "post": {
+        "description": "Returns check relation outcome.",
+        "operationId": "directory.v3.check.relation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v3CheckRelationRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3CheckRelationResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Check relation",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/graph/{anchor_type}/{anchor_id}": {
+      "get": {
+        "description": "Returns object graph from anchor to subject or object.",
+        "operationId": "directory.v3.graph",
+        "parameters": [
+          {
+            "description": "anchor type",
+            "in": "path",
+            "name": "anchor_type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "anchor identifier",
+            "in": "path",
+            "name": "anchor_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "object type.",
+            "in": "query",
+            "name": "object_type",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "object identifier.",
+            "in": "query",
+            "name": "object_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "relation name.",
+            "in": "query",
+            "name": "relation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "subject type.",
+            "in": "query",
+            "name": "subject_type",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "subject identifier.",
+            "in": "query",
+            "name": "subject_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "subject relation.",
+            "in": "query",
+            "name": "subject_relation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3GetGraphResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Get graph",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/object": {
+      "post": {
+        "description": "Set object.",
+        "operationId": "directory.v3.object.set",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v3SetObjectRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3SetObjectResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Set object",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/object/{object_type}/{object_id}": {
+      "delete": {
+        "description": "Delete object.",
+        "operationId": "directory.v3.object.delete",
+        "parameters": [
+          {
+            "description": "object type",
+            "in": "path",
+            "name": "object_type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "object identifier",
+            "in": "path",
+            "name": "object_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "delete object relations, both object and subject relations.",
+            "in": "query",
+            "name": "with_relations",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3DeleteObjectResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Delete object",
+        "tags": [
+          "directory"
+        ]
+      },
+      "get": {
+        "description": "Returns single object instance, optionally with relations.",
+        "operationId": "directory.v3.object.get",
+        "parameters": [
+          {
+            "description": "object type name (lc-string)",
+            "in": "path",
+            "name": "object_type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "object identifier (cs-string)",
+            "in": "path",
+            "name": "object_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "materialize the object relations objects.",
+            "in": "query",
+            "name": "with_relations",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "requested page size, valid value between 1-100 rows (default 100).",
+            "in": "query",
+            "name": "page.size",
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "pagination start token, default \"\".",
+            "in": "query",
+            "name": "page.token",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3GetObjectResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Get object instance",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/objects": {
+      "get": {
+        "description": "Returns list of object instances.",
+        "operationId": "directory.v3.objects.list",
+        "parameters": [
+          {
+            "description": "object type name (lc-string).",
+            "in": "query",
+            "name": "object_type",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "requested page size, valid value between 1-100 rows (default 100).",
+            "in": "query",
+            "name": "page.size",
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "pagination start token, default \"\".",
+            "in": "query",
+            "name": "page.token",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3GetObjectsResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "List object instances",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/relation": {
+      "delete": {
+        "description": "Delete relation.",
+        "operationId": "directory.v3.relation.delete",
+        "parameters": [
+          {
+            "description": "object type.",
+            "in": "query",
+            "name": "object_type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "object identifier.",
+            "in": "query",
+            "name": "object_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "object relation name.",
+            "in": "query",
+            "name": "relation",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "subject type.",
+            "in": "query",
+            "name": "subject_type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "subject identifier.",
+            "in": "query",
+            "name": "subject_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "optional subject relation name.",
+            "in": "query",
+            "name": "subject_relation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3DeleteRelationResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Delete relation",
+        "tags": [
+          "directory"
+        ]
+      },
+      "get": {
+        "description": "Returns single relation instance, optionally with objects.",
+        "operationId": "directory.v3.relation.get",
+        "parameters": [
+          {
+            "description": "object type.",
+            "in": "query",
+            "name": "object_type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "object identifier.",
+            "in": "query",
+            "name": "object_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "relation name.",
+            "in": "query",
+            "name": "relation",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "subject type.",
+            "in": "query",
+            "name": "subject_type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "subject identifier.",
+            "in": "query",
+            "name": "subject_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "optional subject relation name.",
+            "in": "query",
+            "name": "subject_relation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "materialize relation objects.",
+            "in": "query",
+            "name": "with_objects",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3GetRelationResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Get relation instance",
+        "tags": [
+          "directory"
+        ]
+      },
+      "post": {
+        "description": "Set relation.",
+        "operationId": "directory.v3.relation.set",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v3SetRelationRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3SetRelationResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Set relation",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/relations": {
+      "get": {
+        "description": "Returns list of relation instances.",
+        "operationId": "directory.v3.relations.list",
+        "parameters": [
+          {
+            "description": "object type.",
+            "in": "query",
+            "name": "object_type",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "object identifier.",
+            "in": "query",
+            "name": "object_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "relation name.",
+            "in": "query",
+            "name": "relation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "subject type.",
+            "in": "query",
+            "name": "subject_type",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "subject identifier.",
+            "in": "query",
+            "name": "subject_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "optional subject relation name.",
+            "in": "query",
+            "name": "subject_relation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "materialize relation objects.",
+            "in": "query",
+            "name": "with_objects",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "requested page size, valid value between 1-100 rows (default 100).",
+            "in": "query",
+            "name": "page.size",
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "pagination start token, default \"\".",
+            "in": "query",
+            "name": "page.token",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3GetRelationsResponse"
+                }
+              }
+            },
+            "description": "A successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rpcStatus"
+                }
+              }
+            },
+            "description": "An unexpected error response."
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "List relations instances",
+        "tags": [
+          "directory"
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "DirectoryAPIKey": [],
+      "TenantID": []
+    }
+  ],
   "servers": [
     {
       "description": "Aserto Directory service",

--- a/publish/directory/openapi.yaml
+++ b/publish/directory/openapi.yaml
@@ -74,7 +74,65 @@ components:
             value:
               extensionprops: {}
               type: string
-    v2CheckPermissionResponse:
+    v3CheckPermissionRequest:
+      ref: ""
+      value:
+        extensionprops: {}
+        type: object
+        required:
+          - object_type
+          - object_id
+          - permission
+          - subject_type
+          - subject_id
+        properties:
+          object_id:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: object identifier
+              required:
+                - object_id
+          object_type:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: object type
+              required:
+                - object_type
+          permission:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: permission name
+              required:
+                - permission
+          subject_id:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: subject identifier
+              required:
+                - subject_id
+          subject_type:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: subject type
+              required:
+                - subject_type
+          trace:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: boolean
+              title: collect trace information
+    v3CheckPermissionResponse:
       ref: ""
       value:
         extensionprops: {}
@@ -97,7 +155,65 @@ components:
                 value:
                   extensionprops: {}
                   type: string
-    v2CheckRelationResponse:
+    v3CheckRelationRequest:
+      ref: ""
+      value:
+        extensionprops: {}
+        type: object
+        required:
+          - object_type
+          - object_id
+          - relation
+          - subject_type
+          - subject_id
+        properties:
+          object_id:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: object identifier
+              required:
+                - object_id
+          object_type:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: object type
+              required:
+                - object_type
+          relation:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: relation name
+              required:
+                - relation
+          subject_id:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: subject identifier
+              required:
+                - subject_id
+          subject_type:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: subject type
+              required:
+                - subject_type
+          trace:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: boolean
+              title: collect trace information
+    v3CheckRelationResponse:
       ref: ""
       value:
         extensionprops: {}
@@ -120,7 +236,88 @@ components:
                 value:
                   extensionprops: {}
                   type: string
-    v2DeleteObjectResponse:
+    v3CheckRequest:
+      ref: ""
+      value:
+        extensionprops: {}
+        type: object
+        required:
+          - object_type
+          - object_id
+          - relation
+          - subject_type
+          - subject_id
+        properties:
+          object_id:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: object identifier
+              required:
+                - object_id
+          object_type:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: object type
+              required:
+                - object_type
+          relation:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: relation name
+              required:
+                - relation
+          subject_id:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: subject identifier
+              required:
+                - subject_id
+          subject_type:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: subject type
+              required:
+                - subject_type
+          trace:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: boolean
+              title: collect trace information
+    v3CheckResponse:
+      ref: ""
+      value:
+        extensionprops: {}
+        type: object
+        properties:
+          check:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: boolean
+              title: check result
+          trace:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: array
+              title: trace information
+              items:
+                ref: ""
+                value:
+                  extensionprops: {}
+                  type: string
+    v3DeleteObjectResponse:
       ref: ""
       value:
         extensionprops: {}
@@ -131,7 +328,7 @@ components:
             value:
               extensionprops: {}
               title: empty result
-    v2DeleteObjectTypeResponse:
+    v3DeleteRelationResponse:
       ref: ""
       value:
         extensionprops: {}
@@ -142,40 +339,7 @@ components:
             value:
               extensionprops: {}
               title: empty result
-    v2DeletePermissionResponse:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        properties:
-          result:
-            ref: ""
-            value:
-              extensionprops: {}
-              title: empty result
-    v2DeleteRelationResponse:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        properties:
-          result:
-            ref: ""
-            value:
-              extensionprops: {}
-              title: empty result
-    v2DeleteRelationTypeResponse:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        properties:
-          result:
-            ref: ""
-            value:
-              extensionprops: {}
-              title: empty result
-    v2GetGraphResponse:
+    v3GetGraphResponse:
       ref: ""
       value:
         extensionprops: {}
@@ -188,7 +352,7 @@ components:
               type: array
               title: dependency graph
               items:
-                ref: '#/components/schemas/v2ObjectDependency'
+                ref: '#/components/schemas/v3ObjectDependency'
                 value:
                   extensionprops: {}
                   type: object
@@ -200,30 +364,35 @@ components:
                         type: integer
                         title: dependency depth
                         format: int32
+                        readOnly: true
                     is_cycle:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: boolean
                         title: dependency cycle
-                    object_key:
+                        readOnly: true
+                    object_id:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: string
-                        title: object search key of source object
+                        title: object identifier
+                        readOnly: true
                     object_type:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: string
-                        title: object type name of source object
+                        title: object type
+                        readOnly: true
                     path:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: array
                         title: dependency path
+                        readOnly: true
                         items:
                           ref: ""
                           value:
@@ -234,20 +403,30 @@ components:
                       value:
                         extensionprops: {}
                         type: string
-                        title: relation identifier
-                    subject_key:
+                        title: object relation name
+                        readOnly: true
+                    subject_id:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: string
-                        title: object search key of target object
+                        title: subject identifier
+                        readOnly: true
+                    subject_relation:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: optional subject relation name
+                        readOnly: true
                     subject_type:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: string
-                        title: object type id of target object
-    v2GetObjectManyResponse:
+                        title: subject type
+                        readOnly: true
+    v3GetObjectManyResponse:
       ref: ""
       value:
         extensionprops: {}
@@ -260,10 +439,13 @@ components:
               type: array
               title: array of object instances
               items:
-                ref: '#/components/schemas/v2Object'
+                ref: '#/components/schemas/v3Object'
                 value:
                   extensionprops: {}
                   type: object
+                  required:
+                    - type
+                    - id
                   properties:
                     created_at:
                       ref: ""
@@ -272,24 +454,27 @@ components:
                         type: string
                         title: created at timestamp (UTC)
                         format: date-time
+                        readOnly: true
                     display_name:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: string
                         title: display name object
-                    hash:
+                    etag:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: string
-                        title: object instance hash
-                    key:
+                        title: object instance etag
+                    id:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: string
-                        title: external object key (cs-string)
+                        title: external object identifier (cs-string, no spaces or tabs)
+                        required:
+                          - id
                     properties:
                       ref: ""
                       value:
@@ -302,6 +487,8 @@ components:
                         extensionprops: {}
                         type: string
                         title: object type name
+                        required:
+                          - type
                     updated_at:
                       ref: ""
                       value:
@@ -309,14 +496,15 @@ components:
                         type: string
                         title: last updated timestamp (UTC)
                         format: date-time
-    v2GetObjectResponse:
+                        readOnly: true
+    v3GetObjectResponse:
       ref: ""
       value:
         extensionprops: {}
         type: object
         properties:
           page:
-            ref: '#/components/schemas/v2PaginationResponse'
+            ref: '#/components/schemas/v3PaginationResponse'
             value:
               extensionprops: {}
               type: object
@@ -328,13 +516,7 @@ components:
                     extensionprops: {}
                     type: string
                     title: next page token, when empty there are no more pages to fetch
-                result_size:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: integer
-                    title: result size of the page returned
-                    format: int32
+                    readOnly: true
           relations:
             ref: ""
             value:
@@ -342,10 +524,16 @@ components:
               type: array
               title: object relations
               items:
-                ref: '#/components/schemas/v2Relation'
+                ref: '#/components/schemas/v3Relation'
                 value:
                   extensionprops: {}
                   type: object
+                  required:
+                    - object_type
+                    - object_id
+                    - relation
+                    - subject_type
+                    - subject_id
                   properties:
                     created_at:
                       ref: ""
@@ -354,56 +542,59 @@ components:
                         type: string
                         title: created at timestamp (UTC)
                         format: date-time
-                    hash:
+                        readOnly: true
+                    etag:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: string
-                        title: object instance hash
-                    object:
-                      ref: '#/components/schemas/v2ObjectIdentifier'
+                        title: object instance etag
+                    object_id:
+                      ref: ""
                       value:
                         extensionprops: {}
-                        type: object
-                        title: Object identifier
-                        properties:
-                          key:
-                            ref: ""
-                            value:
-                              extensionprops: {}
-                              type: string
-                              title: external object key (cs-string)
-                          type:
-                            ref: ""
-                            value:
-                              extensionprops: {}
-                              type: string
-                              title: object type
+                        type: string
+                        title: object identifier
+                        required:
+                          - object_id
+                    object_type:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: object type
+                        required:
+                          - object_type
                     relation:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: string
-                        title: relation type name
-                    subject:
-                      ref: '#/components/schemas/v2ObjectIdentifier'
+                        title: object relation name
+                        required:
+                          - relation
+                    subject_id:
+                      ref: ""
                       value:
                         extensionprops: {}
-                        type: object
-                        title: Object identifier
-                        properties:
-                          key:
-                            ref: ""
-                            value:
-                              extensionprops: {}
-                              type: string
-                              title: external object key (cs-string)
-                          type:
-                            ref: ""
-                            value:
-                              extensionprops: {}
-                              type: string
-                              title: object type
+                        type: string
+                        title: subject identifier
+                        required:
+                          - subject_id
+                    subject_relation:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: optional subject relation name
+                    subject_type:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: subject type
+                        required:
+                          - subject_type
                     updated_at:
                       ref: ""
                       value:
@@ -411,11 +602,15 @@ components:
                         type: string
                         title: last updated timestamp (UTC)
                         format: date-time
+                        readOnly: true
           result:
-            ref: '#/components/schemas/v2Object'
+            ref: '#/components/schemas/v3Object'
             value:
               extensionprops: {}
               type: object
+              required:
+                - type
+                - id
               properties:
                 created_at:
                   ref: ""
@@ -424,24 +619,27 @@ components:
                     type: string
                     title: created at timestamp (UTC)
                     format: date-time
+                    readOnly: true
                 display_name:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: string
                     title: display name object
-                hash:
+                etag:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: string
-                    title: object instance hash
-                key:
+                    title: object instance etag
+                id:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: string
-                    title: external object key (cs-string)
+                    title: external object identifier (cs-string, no spaces or tabs)
+                    required:
+                      - id
                 properties:
                   ref: ""
                   value:
@@ -454,6 +652,8 @@ components:
                     extensionprops: {}
                     type: string
                     title: object type name
+                    required:
+                      - type
                 updated_at:
                   ref: ""
                   value:
@@ -461,84 +661,15 @@ components:
                     type: string
                     title: last updated timestamp (UTC)
                     format: date-time
-    v2GetObjectTypeResponse:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        properties:
-          result:
-            ref: '#/components/schemas/v2ObjectType'
-            value:
-              extensionprops: {}
-              type: object
-              properties:
-                created_at:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: created at timestamp (UTC)
-                    format: date-time
-                display_name:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: object type display name
-                hash:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: object instance hash
-                is_subject:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: boolean
-                    title: object type is a subject (user|group) (default false)
-                name:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: object type name (unique, lc-string)
-                ordinal:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: integer
-                    title: sort ordinal (default 0)
-                    format: int32
-                schema:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: object
-                    title: object type schema definition (JSON)
-                status:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: integer
-                    title: status flag bitmap (default 0)
-                    format: int64
-                updated_at:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: last updated timestamp (UTC)
-                    format: date-time
-    v2GetObjectTypesResponse:
+                    readOnly: true
+    v3GetObjectsResponse:
       ref: ""
       value:
         extensionprops: {}
         type: object
         properties:
           page:
-            ref: '#/components/schemas/v2PaginationResponse'
+            ref: '#/components/schemas/v3PaginationResponse'
             value:
               extensionprops: {}
               type: object
@@ -550,109 +681,7 @@ components:
                     extensionprops: {}
                     type: string
                     title: next page token, when empty there are no more pages to fetch
-                result_size:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: integer
-                    title: result size of the page returned
-                    format: int32
-          results:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: array
-              title: array of object types
-              items:
-                ref: '#/components/schemas/v2ObjectType'
-                value:
-                  extensionprops: {}
-                  type: object
-                  properties:
-                    created_at:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: created at timestamp (UTC)
-                        format: date-time
-                    display_name:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: object type display name
-                    hash:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: object instance hash
-                    is_subject:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: boolean
-                        title: object type is a subject (user|group) (default false)
-                    name:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: object type name (unique, lc-string)
-                    ordinal:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: integer
-                        title: sort ordinal (default 0)
-                        format: int32
-                    schema:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: object
-                        title: object type schema definition (JSON)
-                    status:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: integer
-                        title: status flag bitmap (default 0)
-                        format: int64
-                    updated_at:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: last updated timestamp (UTC)
-                        format: date-time
-    v2GetObjectsResponse:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        properties:
-          page:
-            ref: '#/components/schemas/v2PaginationResponse'
-            value:
-              extensionprops: {}
-              type: object
-              title: Pagination response
-              properties:
-                next_token:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: next page token, when empty there are no more pages to fetch
-                result_size:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: integer
-                    title: result size of the page returned
-                    format: int32
+                    readOnly: true
           results:
             ref: ""
             value:
@@ -660,10 +689,13 @@ components:
               type: array
               title: array of object instances
               items:
-                ref: '#/components/schemas/v2Object'
+                ref: '#/components/schemas/v3Object'
                 value:
                   extensionprops: {}
                   type: object
+                  required:
+                    - type
+                    - id
                   properties:
                     created_at:
                       ref: ""
@@ -672,24 +704,27 @@ components:
                         type: string
                         title: created at timestamp (UTC)
                         format: date-time
+                        readOnly: true
                     display_name:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: string
                         title: display name object
-                    hash:
+                    etag:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: string
-                        title: object instance hash
-                    key:
+                        title: object instance etag
+                    id:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: string
-                        title: external object key (cs-string)
+                        title: external object identifier (cs-string, no spaces or tabs)
+                        required:
+                          - id
                     properties:
                       ref: ""
                       value:
@@ -702,6 +737,8 @@ components:
                         extensionprops: {}
                         type: string
                         title: object type name
+                        required:
+                          - type
                     updated_at:
                       ref: ""
                       value:
@@ -709,121 +746,8 @@ components:
                         type: string
                         title: last updated timestamp (UTC)
                         format: date-time
-    v2GetPermissionResponse:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        properties:
-          result:
-            ref: '#/components/schemas/v2Permission'
-            value:
-              extensionprops: {}
-              type: object
-              properties:
-                created_at:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: created at timestamp (UTC)
-                    format: date-time
-                display_name:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: permission display name
-                hash:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: object instance hash
-                name:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: permission name (unique, cs-string)
-                updated_at:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: last updated timestamp (UTC)
-                    format: date-time
-    v2GetPermissionsResponse:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        properties:
-          page:
-            ref: '#/components/schemas/v2PaginationResponse'
-            value:
-              extensionprops: {}
-              type: object
-              title: Pagination response
-              properties:
-                next_token:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: next page token, when empty there are no more pages to fetch
-                result_size:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: integer
-                    title: result size of the page returned
-                    format: int32
-          results:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: array
-              title: array of permissions
-              items:
-                ref: '#/components/schemas/v2Permission'
-                value:
-                  extensionprops: {}
-                  type: object
-                  properties:
-                    created_at:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: created at timestamp (UTC)
-                        format: date-time
-                    display_name:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: permission display name
-                    hash:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: object instance hash
-                    name:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: permission name (unique, cs-string)
-                    updated_at:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: last updated timestamp (UTC)
-                        format: date-time
-    v2GetRelationResponse:
+                        readOnly: true
+    v3GetRelationResponse:
       ref: ""
       value:
         extensionprops: {}
@@ -835,93 +759,17 @@ components:
               extensionprops: {}
               type: object
               title: map of materialized relation objects
-          results:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: array
-              title: array of relation instances
-              items:
-                ref: '#/components/schemas/v2Relation'
-                value:
-                  extensionprops: {}
-                  type: object
-                  properties:
-                    created_at:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: created at timestamp (UTC)
-                        format: date-time
-                    hash:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: object instance hash
-                    object:
-                      ref: '#/components/schemas/v2ObjectIdentifier'
-                      value:
-                        extensionprops: {}
-                        type: object
-                        title: Object identifier
-                        properties:
-                          key:
-                            ref: ""
-                            value:
-                              extensionprops: {}
-                              type: string
-                              title: external object key (cs-string)
-                          type:
-                            ref: ""
-                            value:
-                              extensionprops: {}
-                              type: string
-                              title: object type
-                    relation:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: relation type name
-                    subject:
-                      ref: '#/components/schemas/v2ObjectIdentifier'
-                      value:
-                        extensionprops: {}
-                        type: object
-                        title: Object identifier
-                        properties:
-                          key:
-                            ref: ""
-                            value:
-                              extensionprops: {}
-                              type: string
-                              title: external object key (cs-string)
-                          type:
-                            ref: ""
-                            value:
-                              extensionprops: {}
-                              type: string
-                              title: object type
-                    updated_at:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: last updated timestamp (UTC)
-                        format: date-time
-    v2GetRelationTypeResponse:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        properties:
           result:
-            ref: '#/components/schemas/v2RelationType'
+            ref: '#/components/schemas/v3Relation'
             value:
               extensionprops: {}
               type: object
+              required:
+                - object_type
+                - object_id
+                - relation
+                - subject_type
+                - subject_id
               properties:
                 created_at:
                   ref: ""
@@ -930,66 +778,59 @@ components:
                     type: string
                     title: created at timestamp (UTC)
                     format: date-time
-                display_name:
+                    readOnly: true
+                etag:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: string
-                    title: relation display name
-                hash:
+                    title: object instance etag
+                object_id:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: string
-                    title: object instance hash
-                name:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: relation type name selector
+                    title: object identifier
+                    required:
+                      - object_id
                 object_type:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: string
-                    title: object type referenced by relation
-                ordinal:
+                    title: object type
+                    required:
+                      - object_type
+                relation:
                   ref: ""
                   value:
                     extensionprops: {}
-                    type: integer
-                    title: sort ordinal (default 0)
-                    format: int32
-                permissions:
+                    type: string
+                    title: object relation name
+                    required:
+                      - relation
+                subject_id:
                   ref: ""
                   value:
                     extensionprops: {}
-                    type: array
-                    title: permissions associated to relation type instance
-                    items:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                status:
+                    type: string
+                    title: subject identifier
+                    required:
+                      - subject_id
+                subject_relation:
                   ref: ""
                   value:
                     extensionprops: {}
-                    type: integer
-                    title: status bitmap (default 0)
-                    format: int64
-                unions:
+                    type: string
+                    title: optional subject relation name
+                subject_type:
                   ref: ""
                   value:
                     extensionprops: {}
-                    type: array
-                    title: relations union-ed with relation type instance
-                    items:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
+                    type: string
+                    title: subject type
+                    required:
+                      - subject_type
                 updated_at:
                   ref: ""
                   value:
@@ -997,126 +838,21 @@ components:
                     type: string
                     title: last updated timestamp (UTC)
                     format: date-time
-    v2GetRelationTypesResponse:
+                    readOnly: true
+    v3GetRelationsResponse:
       ref: ""
       value:
         extensionprops: {}
         type: object
         properties:
-          page:
-            ref: '#/components/schemas/v2PaginationResponse'
-            value:
-              extensionprops: {}
-              type: object
-              title: Pagination response
-              properties:
-                next_token:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: next page token, when empty there are no more pages to fetch
-                result_size:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: integer
-                    title: result size of the page returned
-                    format: int32
-          results:
+          objects:
             ref: ""
             value:
               extensionprops: {}
-              type: array
-              title: array of relation types
-              items:
-                ref: '#/components/schemas/v2RelationType'
-                value:
-                  extensionprops: {}
-                  type: object
-                  properties:
-                    created_at:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: created at timestamp (UTC)
-                        format: date-time
-                    display_name:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: relation display name
-                    hash:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: object instance hash
-                    name:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: relation type name selector
-                    object_type:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: object type referenced by relation
-                    ordinal:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: integer
-                        title: sort ordinal (default 0)
-                        format: int32
-                    permissions:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: array
-                        title: permissions associated to relation type instance
-                        items:
-                          ref: ""
-                          value:
-                            extensionprops: {}
-                            type: string
-                    status:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: integer
-                        title: status bitmap (default 0)
-                        format: int64
-                    unions:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: array
-                        title: relations union-ed with relation type instance
-                        items:
-                          ref: ""
-                          value:
-                            extensionprops: {}
-                            type: string
-                    updated_at:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                        title: last updated timestamp (UTC)
-                        format: date-time
-    v2GetRelationsResponse:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        properties:
+              type: object
+              title: map of materialized relation objects
           page:
-            ref: '#/components/schemas/v2PaginationResponse'
+            ref: '#/components/schemas/v3PaginationResponse'
             value:
               extensionprops: {}
               type: object
@@ -1128,13 +864,7 @@ components:
                     extensionprops: {}
                     type: string
                     title: next page token, when empty there are no more pages to fetch
-                result_size:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: integer
-                    title: result size of the page returned
-                    format: int32
+                    readOnly: true
           results:
             ref: ""
             value:
@@ -1142,10 +872,16 @@ components:
               type: array
               title: array of relation instances
               items:
-                ref: '#/components/schemas/v2Relation'
+                ref: '#/components/schemas/v3Relation'
                 value:
                   extensionprops: {}
                   type: object
+                  required:
+                    - object_type
+                    - object_id
+                    - relation
+                    - subject_type
+                    - subject_id
                   properties:
                     created_at:
                       ref: ""
@@ -1154,56 +890,59 @@ components:
                         type: string
                         title: created at timestamp (UTC)
                         format: date-time
-                    hash:
+                        readOnly: true
+                    etag:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: string
-                        title: object instance hash
-                    object:
-                      ref: '#/components/schemas/v2ObjectIdentifier'
+                        title: object instance etag
+                    object_id:
+                      ref: ""
                       value:
                         extensionprops: {}
-                        type: object
-                        title: Object identifier
-                        properties:
-                          key:
-                            ref: ""
-                            value:
-                              extensionprops: {}
-                              type: string
-                              title: external object key (cs-string)
-                          type:
-                            ref: ""
-                            value:
-                              extensionprops: {}
-                              type: string
-                              title: object type
+                        type: string
+                        title: object identifier
+                        required:
+                          - object_id
+                    object_type:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: object type
+                        required:
+                          - object_type
                     relation:
                       ref: ""
                       value:
                         extensionprops: {}
                         type: string
-                        title: relation type name
-                    subject:
-                      ref: '#/components/schemas/v2ObjectIdentifier'
+                        title: object relation name
+                        required:
+                          - relation
+                    subject_id:
+                      ref: ""
                       value:
                         extensionprops: {}
-                        type: object
-                        title: Object identifier
-                        properties:
-                          key:
-                            ref: ""
-                            value:
-                              extensionprops: {}
-                              type: string
-                              title: external object key (cs-string)
-                          type:
-                            ref: ""
-                            value:
-                              extensionprops: {}
-                              type: string
-                              title: object type
+                        type: string
+                        title: subject identifier
+                        required:
+                          - subject_id
+                    subject_relation:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: optional subject relation name
+                    subject_type:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: subject type
+                        required:
+                          - subject_type
                     updated_at:
                       ref: ""
                       value:
@@ -1211,11 +950,15 @@ components:
                         type: string
                         title: last updated timestamp (UTC)
                         format: date-time
-    v2Object:
+                        readOnly: true
+    v3Object:
       ref: ""
       value:
         extensionprops: {}
         type: object
+        required:
+          - type
+          - id
         properties:
           created_at:
             ref: ""
@@ -1224,24 +967,27 @@ components:
               type: string
               title: created at timestamp (UTC)
               format: date-time
+              readOnly: true
           display_name:
             ref: ""
             value:
               extensionprops: {}
               type: string
               title: display name object
-          hash:
+          etag:
             ref: ""
             value:
               extensionprops: {}
               type: string
-              title: object instance hash
-          key:
+              title: object instance etag
+          id:
             ref: ""
             value:
               extensionprops: {}
               type: string
-              title: external object key (cs-string)
+              title: external object identifier (cs-string, no spaces or tabs)
+              required:
+                - id
           properties:
             ref: ""
             value:
@@ -1254,6 +1000,8 @@ components:
               extensionprops: {}
               type: string
               title: object type name
+              required:
+                - type
           updated_at:
             ref: ""
             value:
@@ -1261,7 +1009,8 @@ components:
               type: string
               title: last updated timestamp (UTC)
               format: date-time
-    v2ObjectDependency:
+              readOnly: true
+    v3ObjectDependency:
       ref: ""
       value:
         extensionprops: {}
@@ -1274,30 +1023,35 @@ components:
               type: integer
               title: dependency depth
               format: int32
+              readOnly: true
           is_cycle:
             ref: ""
             value:
               extensionprops: {}
               type: boolean
               title: dependency cycle
-          object_key:
+              readOnly: true
+          object_id:
             ref: ""
             value:
               extensionprops: {}
               type: string
-              title: object search key of source object
+              title: object identifier
+              readOnly: true
           object_type:
             ref: ""
             value:
               extensionprops: {}
               type: string
-              title: object type name of source object
+              title: object type
+              readOnly: true
           path:
             ref: ""
             value:
               extensionprops: {}
               type: array
               title: dependency path
+              readOnly: true
               items:
                 ref: ""
                 value:
@@ -1308,116 +1062,56 @@ components:
             value:
               extensionprops: {}
               type: string
-              title: relation identifier
-          subject_key:
+              title: object relation name
+              readOnly: true
+          subject_id:
             ref: ""
             value:
               extensionprops: {}
               type: string
-              title: object search key of target object
+              title: subject identifier
+              readOnly: true
+          subject_relation:
+            ref: ""
+            value:
+              extensionprops: {}
+              type: string
+              title: optional subject relation name
+              readOnly: true
           subject_type:
             ref: ""
             value:
               extensionprops: {}
               type: string
-              title: object type id of target object
-    v2ObjectIdentifier:
+              title: subject type
+              readOnly: true
+    v3ObjectIdentifier:
       ref: ""
       value:
         extensionprops: {}
         type: object
         title: Object identifier
+        required:
+          - object_type
+          - object_id
         properties:
-          key:
+          object_id:
             ref: ""
             value:
               extensionprops: {}
               type: string
-              title: external object key (cs-string)
-          type:
+              title: object identifier (cs-string)
+              required:
+                - object_id
+          object_type:
             ref: ""
             value:
               extensionprops: {}
               type: string
-              title: object type
-    v2ObjectType:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        properties:
-          created_at:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: created at timestamp (UTC)
-              format: date-time
-          display_name:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: object type display name
-          hash:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: object instance hash
-          is_subject:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: boolean
-              title: object type is a subject (user|group) (default false)
-          name:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: object type name (unique, lc-string)
-          ordinal:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: integer
-              title: sort ordinal (default 0)
-              format: int32
-          schema:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: object
-              title: object type schema definition (JSON)
-          status:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: integer
-              title: status flag bitmap (default 0)
-              format: int64
-          updated_at:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: last updated timestamp (UTC)
-              format: date-time
-    v2ObjectTypeIdentifier:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        title: ObjectType identifier
-        properties:
-          name:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: object type name (unique, lc-string)
-    v2PaginationRequest:
+              title: object type (lc-string)
+              required:
+                - object_type
+    v3PaginationRequest:
       ref: ""
       value:
         extensionprops: {}
@@ -1437,7 +1131,7 @@ components:
               extensionprops: {}
               type: string
               title: pagination start token, default ""
-    v2PaginationResponse:
+    v3PaginationResponse:
       ref: ""
       value:
         extensionprops: {}
@@ -1450,18 +1144,18 @@ components:
               extensionprops: {}
               type: string
               title: next page token, when empty there are no more pages to fetch
-          result_size:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: integer
-              title: result size of the page returned
-              format: int32
-    v2Permission:
+              readOnly: true
+    v3Relation:
       ref: ""
       value:
         extensionprops: {}
         type: object
+        required:
+          - object_type
+          - object_id
+          - relation
+          - subject_type
+          - subject_id
         properties:
           created_at:
             ref: ""
@@ -1470,251 +1164,59 @@ components:
               type: string
               title: created at timestamp (UTC)
               format: date-time
-          display_name:
+              readOnly: true
+          etag:
             ref: ""
             value:
               extensionprops: {}
               type: string
-              title: permission display name
-          hash:
+              title: object instance etag
+          object_id:
             ref: ""
             value:
               extensionprops: {}
               type: string
-              title: object instance hash
-          name:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: permission name (unique, cs-string)
-          updated_at:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: last updated timestamp (UTC)
-              format: date-time
-    v2PermissionIdentifier:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        title: Permission identifier
-        properties:
-          name:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: permission name (unique, cs-string)
-    v2Relation:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        properties:
-          created_at:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: created at timestamp (UTC)
-              format: date-time
-          hash:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: object instance hash
-          object:
-            ref: '#/components/schemas/v2ObjectIdentifier'
-            value:
-              extensionprops: {}
-              type: object
-              title: Object identifier
-              properties:
-                key:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: external object key (cs-string)
-                type:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: object type
-          relation:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: relation type name
-          subject:
-            ref: '#/components/schemas/v2ObjectIdentifier'
-            value:
-              extensionprops: {}
-              type: object
-              title: Object identifier
-              properties:
-                key:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: external object key (cs-string)
-                type:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: object type
-          updated_at:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: last updated timestamp (UTC)
-              format: date-time
-    v2RelationIdentifier:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        title: Relation identifier
-        properties:
-          object:
-            ref: '#/components/schemas/v2ObjectIdentifier'
-            value:
-              extensionprops: {}
-              type: object
-              title: Object identifier
-              properties:
-                key:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: external object key (cs-string)
-                type:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: object type
-          relation:
-            ref: '#/components/schemas/v2RelationTypeIdentifier'
-            value:
-              extensionprops: {}
-              type: object
-              title: RelationType identifier
-              properties:
-                name:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: relation type name selector
-                object_type:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: object type referenced by relation
-          subject:
-            ref: '#/components/schemas/v2ObjectIdentifier'
-            value:
-              extensionprops: {}
-              type: object
-              title: Object identifier
-              properties:
-                key:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: external object key (cs-string)
-                type:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: object type
-    v2RelationType:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        properties:
-          created_at:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: created at timestamp (UTC)
-              format: date-time
-          display_name:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: relation display name
-          hash:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: object instance hash
-          name:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: relation type name selector
+              title: object identifier
+              required:
+                - object_id
           object_type:
             ref: ""
             value:
               extensionprops: {}
               type: string
-              title: object type referenced by relation
-          ordinal:
+              title: object type
+              required:
+                - object_type
+          relation:
             ref: ""
             value:
               extensionprops: {}
-              type: integer
-              title: sort ordinal (default 0)
-              format: int32
-          permissions:
+              type: string
+              title: object relation name
+              required:
+                - relation
+          subject_id:
             ref: ""
             value:
               extensionprops: {}
-              type: array
-              title: permissions associated to relation type instance
-              items:
-                ref: ""
-                value:
-                  extensionprops: {}
-                  type: string
-          status:
+              type: string
+              title: subject identifier
+              required:
+                - subject_id
+          subject_relation:
             ref: ""
             value:
               extensionprops: {}
-              type: integer
-              title: status bitmap (default 0)
-              format: int64
-          unions:
+              type: string
+              title: optional subject relation name
+          subject_type:
             ref: ""
             value:
               extensionprops: {}
-              type: array
-              title: relations union-ed with relation type instance
-              items:
-                ref: ""
-                value:
-                  extensionprops: {}
-                  type: string
+              type: string
+              title: subject type
+              required:
+                - subject_type
           updated_at:
             ref: ""
             value:
@@ -1722,36 +1224,21 @@ components:
               type: string
               title: last updated timestamp (UTC)
               format: date-time
-    v2RelationTypeIdentifier:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        title: RelationType identifier
-        properties:
-          name:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: relation type name selector
-          object_type:
-            ref: ""
-            value:
-              extensionprops: {}
-              type: string
-              title: object type referenced by relation
-    v2SetObjectResponse:
+              readOnly: true
+    v3SetObjectRequest:
       ref: ""
       value:
         extensionprops: {}
         type: object
         properties:
-          result:
-            ref: '#/components/schemas/v2Object'
+          object:
+            ref: '#/components/schemas/v3Object'
             value:
               extensionprops: {}
               type: object
+              required:
+                - type
+                - id
               properties:
                 created_at:
                   ref: ""
@@ -1760,24 +1247,27 @@ components:
                     type: string
                     title: created at timestamp (UTC)
                     format: date-time
+                    readOnly: true
                 display_name:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: string
                     title: display name object
-                hash:
+                etag:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: string
-                    title: object instance hash
-                key:
+                    title: object instance etag
+                id:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: string
-                    title: external object key (cs-string)
+                    title: external object identifier (cs-string, no spaces or tabs)
+                    required:
+                      - id
                 properties:
                   ref: ""
                   value:
@@ -1790,6 +1280,8 @@ components:
                     extensionprops: {}
                     type: string
                     title: object type name
+                    required:
+                      - type
                 updated_at:
                   ref: ""
                   value:
@@ -1797,17 +1289,21 @@ components:
                     type: string
                     title: last updated timestamp (UTC)
                     format: date-time
-    v2SetObjectTypeResponse:
+                    readOnly: true
+    v3SetObjectResponse:
       ref: ""
       value:
         extensionprops: {}
         type: object
         properties:
           result:
-            ref: '#/components/schemas/v2ObjectType'
+            ref: '#/components/schemas/v3Object'
             value:
               extensionprops: {}
               type: object
+              required:
+                - type
+                - id
               properties:
                 created_at:
                   ref: ""
@@ -1816,50 +1312,41 @@ components:
                     type: string
                     title: created at timestamp (UTC)
                     format: date-time
+                    readOnly: true
                 display_name:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: string
-                    title: object type display name
-                hash:
+                    title: display name object
+                etag:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: string
-                    title: object instance hash
-                is_subject:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: boolean
-                    title: object type is a subject (user|group) (default false)
-                name:
+                    title: object instance etag
+                id:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: string
-                    title: object type name (unique, lc-string)
-                ordinal:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: integer
-                    title: sort ordinal (default 0)
-                    format: int32
-                schema:
+                    title: external object identifier (cs-string, no spaces or tabs)
+                    required:
+                      - id
+                properties:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: object
-                    title: object type schema definition (JSON)
-                status:
+                    title: property bag
+                type:
                   ref: ""
                   value:
                     extensionprops: {}
-                    type: integer
-                    title: status flag bitmap (default 0)
-                    format: int64
+                    type: string
+                    title: object type name
+                    required:
+                      - type
                 updated_at:
                   ref: ""
                   value:
@@ -1867,17 +1354,24 @@ components:
                     type: string
                     title: last updated timestamp (UTC)
                     format: date-time
-    v2SetPermissionResponse:
+                    readOnly: true
+    v3SetRelationRequest:
       ref: ""
       value:
         extensionprops: {}
         type: object
         properties:
-          result:
-            ref: '#/components/schemas/v2Permission'
+          relation:
+            ref: '#/components/schemas/v3Relation'
             value:
               extensionprops: {}
               type: object
+              required:
+                - object_type
+                - object_id
+                - relation
+                - subject_type
+                - subject_id
               properties:
                 created_at:
                   ref: ""
@@ -1886,186 +1380,59 @@ components:
                     type: string
                     title: created at timestamp (UTC)
                     format: date-time
-                display_name:
+                    readOnly: true
+                etag:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: string
-                    title: permission display name
-                hash:
+                    title: object instance etag
+                object_id:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: string
-                    title: object instance hash
-                name:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: permission name (unique, cs-string)
-                updated_at:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: last updated timestamp (UTC)
-                    format: date-time
-    v2SetRelationResponse:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        properties:
-          result:
-            ref: '#/components/schemas/v2Relation'
-            value:
-              extensionprops: {}
-              type: object
-              properties:
-                created_at:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: created at timestamp (UTC)
-                    format: date-time
-                hash:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: object instance hash
-                object:
-                  ref: '#/components/schemas/v2ObjectIdentifier'
-                  value:
-                    extensionprops: {}
-                    type: object
-                    title: Object identifier
-                    properties:
-                      key:
-                        ref: ""
-                        value:
-                          extensionprops: {}
-                          type: string
-                          title: external object key (cs-string)
-                      type:
-                        ref: ""
-                        value:
-                          extensionprops: {}
-                          type: string
-                          title: object type
-                relation:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: relation type name
-                subject:
-                  ref: '#/components/schemas/v2ObjectIdentifier'
-                  value:
-                    extensionprops: {}
-                    type: object
-                    title: Object identifier
-                    properties:
-                      key:
-                        ref: ""
-                        value:
-                          extensionprops: {}
-                          type: string
-                          title: external object key (cs-string)
-                      type:
-                        ref: ""
-                        value:
-                          extensionprops: {}
-                          type: string
-                          title: object type
-                updated_at:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: last updated timestamp (UTC)
-                    format: date-time
-    v2SetRelationTypeResponse:
-      ref: ""
-      value:
-        extensionprops: {}
-        type: object
-        properties:
-          result:
-            ref: '#/components/schemas/v2RelationType'
-            value:
-              extensionprops: {}
-              type: object
-              properties:
-                created_at:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: created at timestamp (UTC)
-                    format: date-time
-                display_name:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: relation display name
-                hash:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: object instance hash
-                name:
-                  ref: ""
-                  value:
-                    extensionprops: {}
-                    type: string
-                    title: relation type name selector
+                    title: object identifier
+                    required:
+                      - object_id
                 object_type:
                   ref: ""
                   value:
                     extensionprops: {}
                     type: string
-                    title: object type referenced by relation
-                ordinal:
+                    title: object type
+                    required:
+                      - object_type
+                relation:
                   ref: ""
                   value:
                     extensionprops: {}
-                    type: integer
-                    title: sort ordinal (default 0)
-                    format: int32
-                permissions:
+                    type: string
+                    title: object relation name
+                    required:
+                      - relation
+                subject_id:
                   ref: ""
                   value:
                     extensionprops: {}
-                    type: array
-                    title: permissions associated to relation type instance
-                    items:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
-                status:
+                    type: string
+                    title: subject identifier
+                    required:
+                      - subject_id
+                subject_relation:
                   ref: ""
                   value:
                     extensionprops: {}
-                    type: integer
-                    title: status bitmap (default 0)
-                    format: int64
-                unions:
+                    type: string
+                    title: optional subject relation name
+                subject_type:
                   ref: ""
                   value:
                     extensionprops: {}
-                    type: array
-                    title: relations union-ed with relation type instance
-                    items:
-                      ref: ""
-                      value:
-                        extensionprops: {}
-                        type: string
+                    type: string
+                    title: subject type
+                    required:
+                      - subject_type
                 updated_at:
                   ref: ""
                   value:
@@ -2073,6 +1440,109 @@ components:
                     type: string
                     title: last updated timestamp (UTC)
                     format: date-time
+                    readOnly: true
+    v3SetRelationResponse:
+      ref: ""
+      value:
+        extensionprops: {}
+        type: object
+        properties:
+          result:
+            ref: '#/components/schemas/v3Relation'
+            value:
+              extensionprops: {}
+              type: object
+              required:
+                - object_type
+                - object_id
+                - relation
+                - subject_type
+                - subject_id
+              properties:
+                created_at:
+                  ref: ""
+                  value:
+                    extensionprops: {}
+                    type: string
+                    title: created at timestamp (UTC)
+                    format: date-time
+                    readOnly: true
+                etag:
+                  ref: ""
+                  value:
+                    extensionprops: {}
+                    type: string
+                    title: object instance etag
+                object_id:
+                  ref: ""
+                  value:
+                    extensionprops: {}
+                    type: string
+                    title: object identifier
+                    required:
+                      - object_id
+                object_type:
+                  ref: ""
+                  value:
+                    extensionprops: {}
+                    type: string
+                    title: object type
+                    required:
+                      - object_type
+                relation:
+                  ref: ""
+                  value:
+                    extensionprops: {}
+                    type: string
+                    title: object relation name
+                    required:
+                      - relation
+                subject_id:
+                  ref: ""
+                  value:
+                    extensionprops: {}
+                    type: string
+                    title: subject identifier
+                    required:
+                      - subject_id
+                subject_relation:
+                  ref: ""
+                  value:
+                    extensionprops: {}
+                    type: string
+                    title: optional subject relation name
+                subject_type:
+                  ref: ""
+                  value:
+                    extensionprops: {}
+                    type: string
+                    title: subject type
+                    required:
+                      - subject_type
+                updated_at:
+                  ref: ""
+                  value:
+                    extensionprops: {}
+                    type: string
+                    title: last updated timestamp (UTC)
+                    format: date-time
+                    readOnly: true
+  securitySchemes:
+    DirectoryAPIKey:
+      ref: ""
+      value:
+        extensionprops: {}
+        type: apiKey
+        name: authorization
+        in: header
+    TenantID:
+      ref: ""
+      value:
+        extensionprops: {}
+        type: apiKey
+        description: Aserto Tenant ID
+        name: aserto-tenant-id
+        in: header
 info:
   extensionprops: {}
   title: Directory
@@ -2088,7 +1558,2445 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: v0.30.0
-paths: {}
+paths:
+  /api/v3/directory/check:
+    extensionprops: {}
+    post:
+      extensionprops: {}
+      tags:
+        - directory
+      summary: Check
+      description: Returns check outcome.
+      operationId: directory.v3.check
+      requestBody:
+        ref: ""
+        value:
+          extensionprops: {}
+          required: true
+          content:
+            application/json:
+              extensionprops: {}
+              schema:
+                ref: '#/components/schemas/v3CheckRequest'
+                value:
+                  extensionprops: {}
+                  type: object
+                  required:
+                    - object_type
+                    - object_id
+                    - relation
+                    - subject_type
+                    - subject_id
+                  properties:
+                    object_id:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: object identifier
+                        required:
+                          - object_id
+                    object_type:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: object type
+                        required:
+                          - object_type
+                    relation:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: relation name
+                        required:
+                          - relation
+                    subject_id:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: subject identifier
+                        required:
+                          - subject_id
+                    subject_type:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: subject type
+                        required:
+                          - subject_type
+                    trace:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: boolean
+                        title: collect trace information
+      responses:
+        "200":
+          ref: ""
+          value:
+            extensionprops: {}
+            description: A successful response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/v3CheckResponse'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      check:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: boolean
+                          title: check result
+                      trace:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          title: trace information
+                          items:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+        default:
+          ref: ""
+          value:
+            extensionprops: {}
+            description: An unexpected error response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/rpcStatus'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      code:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: integer
+                          format: int32
+                      details:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          items:
+                            ref: '#/components/schemas/protobufAny'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              properties:
+                                type_url:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                value:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    format: byte
+                      message:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: string
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+  /api/v3/directory/check/permission:
+    extensionprops: {}
+    post:
+      extensionprops: {}
+      tags:
+        - directory
+      summary: Check permission
+      description: Returns check permission outcome.
+      operationId: directory.v3.check.permission
+      requestBody:
+        ref: ""
+        value:
+          extensionprops: {}
+          required: true
+          content:
+            application/json:
+              extensionprops: {}
+              schema:
+                ref: '#/components/schemas/v3CheckPermissionRequest'
+                value:
+                  extensionprops: {}
+                  type: object
+                  required:
+                    - object_type
+                    - object_id
+                    - permission
+                    - subject_type
+                    - subject_id
+                  properties:
+                    object_id:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: object identifier
+                        required:
+                          - object_id
+                    object_type:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: object type
+                        required:
+                          - object_type
+                    permission:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: permission name
+                        required:
+                          - permission
+                    subject_id:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: subject identifier
+                        required:
+                          - subject_id
+                    subject_type:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: subject type
+                        required:
+                          - subject_type
+                    trace:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: boolean
+                        title: collect trace information
+      responses:
+        "200":
+          ref: ""
+          value:
+            extensionprops: {}
+            description: A successful response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/v3CheckPermissionResponse'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      check:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: boolean
+                          title: check result
+                      trace:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          title: trace information
+                          items:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+        default:
+          ref: ""
+          value:
+            extensionprops: {}
+            description: An unexpected error response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/rpcStatus'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      code:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: integer
+                          format: int32
+                      details:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          items:
+                            ref: '#/components/schemas/protobufAny'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              properties:
+                                type_url:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                value:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    format: byte
+                      message:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: string
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+  /api/v3/directory/check/relation:
+    extensionprops: {}
+    post:
+      extensionprops: {}
+      tags:
+        - directory
+      summary: Check relation
+      description: Returns check relation outcome.
+      operationId: directory.v3.check.relation
+      requestBody:
+        ref: ""
+        value:
+          extensionprops: {}
+          required: true
+          content:
+            application/json:
+              extensionprops: {}
+              schema:
+                ref: '#/components/schemas/v3CheckRelationRequest'
+                value:
+                  extensionprops: {}
+                  type: object
+                  required:
+                    - object_type
+                    - object_id
+                    - relation
+                    - subject_type
+                    - subject_id
+                  properties:
+                    object_id:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: object identifier
+                        required:
+                          - object_id
+                    object_type:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: object type
+                        required:
+                          - object_type
+                    relation:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: relation name
+                        required:
+                          - relation
+                    subject_id:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: subject identifier
+                        required:
+                          - subject_id
+                    subject_type:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: string
+                        title: subject type
+                        required:
+                          - subject_type
+                    trace:
+                      ref: ""
+                      value:
+                        extensionprops: {}
+                        type: boolean
+                        title: collect trace information
+      responses:
+        "200":
+          ref: ""
+          value:
+            extensionprops: {}
+            description: A successful response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/v3CheckRelationResponse'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      check:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: boolean
+                          title: check result
+                      trace:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          title: trace information
+                          items:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+        default:
+          ref: ""
+          value:
+            extensionprops: {}
+            description: An unexpected error response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/rpcStatus'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      code:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: integer
+                          format: int32
+                      details:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          items:
+                            ref: '#/components/schemas/protobufAny'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              properties:
+                                type_url:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                value:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    format: byte
+                      message:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: string
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+  /api/v3/directory/graph/{anchor_type}/{anchor_id}:
+    extensionprops: {}
+    get:
+      extensionprops: {}
+      tags:
+        - directory
+      summary: Get graph
+      description: Returns object graph from anchor to subject or object.
+      operationId: directory.v3.graph
+      parameters:
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: anchor_type
+            in: path
+            description: anchor type
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: anchor_id
+            in: path
+            description: anchor identifier
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: object_type
+            in: query
+            description: object type.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: object_id
+            in: query
+            description: object identifier.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: relation
+            in: query
+            description: relation name.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: subject_type
+            in: query
+            description: subject type.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: subject_id
+            in: query
+            description: subject identifier.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: subject_relation
+            in: query
+            description: subject relation.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+      responses:
+        "200":
+          ref: ""
+          value:
+            extensionprops: {}
+            description: A successful response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/v3GetGraphResponse'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      results:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          title: dependency graph
+                          items:
+                            ref: '#/components/schemas/v3ObjectDependency'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              properties:
+                                depth:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: integer
+                                    title: dependency depth
+                                    format: int32
+                                    readOnly: true
+                                is_cycle:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: boolean
+                                    title: dependency cycle
+                                    readOnly: true
+                                object_id:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: object identifier
+                                    readOnly: true
+                                object_type:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: object type
+                                    readOnly: true
+                                path:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: array
+                                    title: dependency path
+                                    readOnly: true
+                                    items:
+                                      ref: ""
+                                      value:
+                                        extensionprops: {}
+                                        type: string
+                                relation:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: object relation name
+                                    readOnly: true
+                                subject_id:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: subject identifier
+                                    readOnly: true
+                                subject_relation:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: optional subject relation name
+                                    readOnly: true
+                                subject_type:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: subject type
+                                    readOnly: true
+        default:
+          ref: ""
+          value:
+            extensionprops: {}
+            description: An unexpected error response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/rpcStatus'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      code:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: integer
+                          format: int32
+                      details:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          items:
+                            ref: '#/components/schemas/protobufAny'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              properties:
+                                type_url:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                value:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    format: byte
+                      message:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: string
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+  /api/v3/directory/object:
+    extensionprops: {}
+    post:
+      extensionprops: {}
+      tags:
+        - directory
+      summary: Set object
+      description: Set object.
+      operationId: directory.v3.object.set
+      requestBody:
+        ref: ""
+        value:
+          extensionprops: {}
+          required: true
+          content:
+            application/json:
+              extensionprops: {}
+              schema:
+                ref: '#/components/schemas/v3SetObjectRequest'
+                value:
+                  extensionprops: {}
+                  type: object
+                  properties:
+                    object:
+                      ref: '#/components/schemas/v3Object'
+                      value:
+                        extensionprops: {}
+                        type: object
+                        required:
+                          - type
+                          - id
+                        properties:
+                          created_at:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+                              title: created at timestamp (UTC)
+                              format: date-time
+                              readOnly: true
+                          display_name:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+                              title: display name object
+                          etag:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+                              title: object instance etag
+                          id:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+                              title: external object identifier (cs-string, no spaces or tabs)
+                              required:
+                                - id
+                          properties:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: object
+                              title: property bag
+                          type:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+                              title: object type name
+                              required:
+                                - type
+                          updated_at:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+                              title: last updated timestamp (UTC)
+                              format: date-time
+                              readOnly: true
+      responses:
+        "200":
+          ref: ""
+          value:
+            extensionprops: {}
+            description: A successful response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/v3SetObjectResponse'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      result:
+                        ref: '#/components/schemas/v3Object'
+                        value:
+                          extensionprops: {}
+                          type: object
+                          required:
+                            - type
+                            - id
+                          properties:
+                            created_at:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: created at timestamp (UTC)
+                                format: date-time
+                                readOnly: true
+                            display_name:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: display name object
+                            etag:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: object instance etag
+                            id:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: external object identifier (cs-string, no spaces or tabs)
+                                required:
+                                  - id
+                            properties:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: object
+                                title: property bag
+                            type:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: object type name
+                                required:
+                                  - type
+                            updated_at:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: last updated timestamp (UTC)
+                                format: date-time
+                                readOnly: true
+        default:
+          ref: ""
+          value:
+            extensionprops: {}
+            description: An unexpected error response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/rpcStatus'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      code:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: integer
+                          format: int32
+                      details:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          items:
+                            ref: '#/components/schemas/protobufAny'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              properties:
+                                type_url:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                value:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    format: byte
+                      message:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: string
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+  /api/v3/directory/object/{object_type}/{object_id}:
+    extensionprops: {}
+    delete:
+      extensionprops: {}
+      tags:
+        - directory
+      summary: Delete object
+      description: Delete object.
+      operationId: directory.v3.object.delete
+      parameters:
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: object_type
+            in: path
+            description: object type
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: object_id
+            in: path
+            description: object identifier
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: with_relations
+            in: query
+            description: delete object relations, both object and subject relations.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: boolean
+      responses:
+        "200":
+          ref: ""
+          value:
+            extensionprops: {}
+            description: A successful response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/v3DeleteObjectResponse'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      result:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          title: empty result
+        default:
+          ref: ""
+          value:
+            extensionprops: {}
+            description: An unexpected error response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/rpcStatus'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      code:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: integer
+                          format: int32
+                      details:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          items:
+                            ref: '#/components/schemas/protobufAny'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              properties:
+                                type_url:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                value:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    format: byte
+                      message:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: string
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+    get:
+      extensionprops: {}
+      tags:
+        - directory
+      summary: Get object instance
+      description: Returns single object instance, optionally with relations.
+      operationId: directory.v3.object.get
+      parameters:
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: object_type
+            in: path
+            description: object type name (lc-string)
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: object_id
+            in: path
+            description: object identifier (cs-string)
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: with_relations
+            in: query
+            description: materialize the object relations objects.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: boolean
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: page.size
+            in: query
+            description: requested page size, valid value between 1-100 rows (default 100).
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: integer
+                format: int32
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: page.token
+            in: query
+            description: pagination start token, default "".
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+      responses:
+        "200":
+          ref: ""
+          value:
+            extensionprops: {}
+            description: A successful response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/v3GetObjectResponse'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      page:
+                        ref: '#/components/schemas/v3PaginationResponse'
+                        value:
+                          extensionprops: {}
+                          type: object
+                          title: Pagination response
+                          properties:
+                            next_token:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: next page token, when empty there are no more pages to fetch
+                                readOnly: true
+                      relations:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          title: object relations
+                          items:
+                            ref: '#/components/schemas/v3Relation'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              required:
+                                - object_type
+                                - object_id
+                                - relation
+                                - subject_type
+                                - subject_id
+                              properties:
+                                created_at:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: created at timestamp (UTC)
+                                    format: date-time
+                                    readOnly: true
+                                etag:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: object instance etag
+                                object_id:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: object identifier
+                                    required:
+                                      - object_id
+                                object_type:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: object type
+                                    required:
+                                      - object_type
+                                relation:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: object relation name
+                                    required:
+                                      - relation
+                                subject_id:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: subject identifier
+                                    required:
+                                      - subject_id
+                                subject_relation:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: optional subject relation name
+                                subject_type:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: subject type
+                                    required:
+                                      - subject_type
+                                updated_at:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: last updated timestamp (UTC)
+                                    format: date-time
+                                    readOnly: true
+                      result:
+                        ref: '#/components/schemas/v3Object'
+                        value:
+                          extensionprops: {}
+                          type: object
+                          required:
+                            - type
+                            - id
+                          properties:
+                            created_at:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: created at timestamp (UTC)
+                                format: date-time
+                                readOnly: true
+                            display_name:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: display name object
+                            etag:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: object instance etag
+                            id:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: external object identifier (cs-string, no spaces or tabs)
+                                required:
+                                  - id
+                            properties:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: object
+                                title: property bag
+                            type:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: object type name
+                                required:
+                                  - type
+                            updated_at:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: last updated timestamp (UTC)
+                                format: date-time
+                                readOnly: true
+        default:
+          ref: ""
+          value:
+            extensionprops: {}
+            description: An unexpected error response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/rpcStatus'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      code:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: integer
+                          format: int32
+                      details:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          items:
+                            ref: '#/components/schemas/protobufAny'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              properties:
+                                type_url:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                value:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    format: byte
+                      message:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: string
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+  /api/v3/directory/objects:
+    extensionprops: {}
+    get:
+      extensionprops: {}
+      tags:
+        - directory
+      summary: List object instances
+      description: Returns list of object instances.
+      operationId: directory.v3.objects.list
+      parameters:
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: object_type
+            in: query
+            description: object type name (lc-string).
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: page.size
+            in: query
+            description: requested page size, valid value between 1-100 rows (default 100).
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: integer
+                format: int32
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: page.token
+            in: query
+            description: pagination start token, default "".
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+      responses:
+        "200":
+          ref: ""
+          value:
+            extensionprops: {}
+            description: A successful response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/v3GetObjectsResponse'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      page:
+                        ref: '#/components/schemas/v3PaginationResponse'
+                        value:
+                          extensionprops: {}
+                          type: object
+                          title: Pagination response
+                          properties:
+                            next_token:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: next page token, when empty there are no more pages to fetch
+                                readOnly: true
+                      results:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          title: array of object instances
+                          items:
+                            ref: '#/components/schemas/v3Object'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              required:
+                                - type
+                                - id
+                              properties:
+                                created_at:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: created at timestamp (UTC)
+                                    format: date-time
+                                    readOnly: true
+                                display_name:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: display name object
+                                etag:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: object instance etag
+                                id:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: external object identifier (cs-string, no spaces or tabs)
+                                    required:
+                                      - id
+                                properties:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: object
+                                    title: property bag
+                                type:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: object type name
+                                    required:
+                                      - type
+                                updated_at:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: last updated timestamp (UTC)
+                                    format: date-time
+                                    readOnly: true
+        default:
+          ref: ""
+          value:
+            extensionprops: {}
+            description: An unexpected error response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/rpcStatus'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      code:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: integer
+                          format: int32
+                      details:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          items:
+                            ref: '#/components/schemas/protobufAny'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              properties:
+                                type_url:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                value:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    format: byte
+                      message:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: string
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+  /api/v3/directory/relation:
+    extensionprops: {}
+    delete:
+      extensionprops: {}
+      tags:
+        - directory
+      summary: Delete relation
+      description: Delete relation.
+      operationId: directory.v3.relation.delete
+      parameters:
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: object_type
+            in: query
+            description: object type.
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: object_id
+            in: query
+            description: object identifier.
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: relation
+            in: query
+            description: object relation name.
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: subject_type
+            in: query
+            description: subject type.
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: subject_id
+            in: query
+            description: subject identifier.
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: subject_relation
+            in: query
+            description: optional subject relation name.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+      responses:
+        "200":
+          ref: ""
+          value:
+            extensionprops: {}
+            description: A successful response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/v3DeleteRelationResponse'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      result:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          title: empty result
+        default:
+          ref: ""
+          value:
+            extensionprops: {}
+            description: An unexpected error response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/rpcStatus'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      code:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: integer
+                          format: int32
+                      details:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          items:
+                            ref: '#/components/schemas/protobufAny'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              properties:
+                                type_url:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                value:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    format: byte
+                      message:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: string
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+    get:
+      extensionprops: {}
+      tags:
+        - directory
+      summary: Get relation instance
+      description: Returns single relation instance, optionally with objects.
+      operationId: directory.v3.relation.get
+      parameters:
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: object_type
+            in: query
+            description: object type.
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: object_id
+            in: query
+            description: object identifier.
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: relation
+            in: query
+            description: relation name.
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: subject_type
+            in: query
+            description: subject type.
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: subject_id
+            in: query
+            description: subject identifier.
+            required: true
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: subject_relation
+            in: query
+            description: optional subject relation name.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: with_objects
+            in: query
+            description: materialize relation objects.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: boolean
+      responses:
+        "200":
+          ref: ""
+          value:
+            extensionprops: {}
+            description: A successful response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/v3GetRelationResponse'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      objects:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: object
+                          title: map of materialized relation objects
+                      result:
+                        ref: '#/components/schemas/v3Relation'
+                        value:
+                          extensionprops: {}
+                          type: object
+                          required:
+                            - object_type
+                            - object_id
+                            - relation
+                            - subject_type
+                            - subject_id
+                          properties:
+                            created_at:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: created at timestamp (UTC)
+                                format: date-time
+                                readOnly: true
+                            etag:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: object instance etag
+                            object_id:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: object identifier
+                                required:
+                                  - object_id
+                            object_type:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: object type
+                                required:
+                                  - object_type
+                            relation:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: object relation name
+                                required:
+                                  - relation
+                            subject_id:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: subject identifier
+                                required:
+                                  - subject_id
+                            subject_relation:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: optional subject relation name
+                            subject_type:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: subject type
+                                required:
+                                  - subject_type
+                            updated_at:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: last updated timestamp (UTC)
+                                format: date-time
+                                readOnly: true
+        default:
+          ref: ""
+          value:
+            extensionprops: {}
+            description: An unexpected error response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/rpcStatus'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      code:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: integer
+                          format: int32
+                      details:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          items:
+                            ref: '#/components/schemas/protobufAny'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              properties:
+                                type_url:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                value:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    format: byte
+                      message:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: string
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+    post:
+      extensionprops: {}
+      tags:
+        - directory
+      summary: Set relation
+      description: Set relation.
+      operationId: directory.v3.relation.set
+      requestBody:
+        ref: ""
+        value:
+          extensionprops: {}
+          required: true
+          content:
+            application/json:
+              extensionprops: {}
+              schema:
+                ref: '#/components/schemas/v3SetRelationRequest'
+                value:
+                  extensionprops: {}
+                  type: object
+                  properties:
+                    relation:
+                      ref: '#/components/schemas/v3Relation'
+                      value:
+                        extensionprops: {}
+                        type: object
+                        required:
+                          - object_type
+                          - object_id
+                          - relation
+                          - subject_type
+                          - subject_id
+                        properties:
+                          created_at:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+                              title: created at timestamp (UTC)
+                              format: date-time
+                              readOnly: true
+                          etag:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+                              title: object instance etag
+                          object_id:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+                              title: object identifier
+                              required:
+                                - object_id
+                          object_type:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+                              title: object type
+                              required:
+                                - object_type
+                          relation:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+                              title: object relation name
+                              required:
+                                - relation
+                          subject_id:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+                              title: subject identifier
+                              required:
+                                - subject_id
+                          subject_relation:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+                              title: optional subject relation name
+                          subject_type:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+                              title: subject type
+                              required:
+                                - subject_type
+                          updated_at:
+                            ref: ""
+                            value:
+                              extensionprops: {}
+                              type: string
+                              title: last updated timestamp (UTC)
+                              format: date-time
+                              readOnly: true
+      responses:
+        "200":
+          ref: ""
+          value:
+            extensionprops: {}
+            description: A successful response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/v3SetRelationResponse'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      result:
+                        ref: '#/components/schemas/v3Relation'
+                        value:
+                          extensionprops: {}
+                          type: object
+                          required:
+                            - object_type
+                            - object_id
+                            - relation
+                            - subject_type
+                            - subject_id
+                          properties:
+                            created_at:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: created at timestamp (UTC)
+                                format: date-time
+                                readOnly: true
+                            etag:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: object instance etag
+                            object_id:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: object identifier
+                                required:
+                                  - object_id
+                            object_type:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: object type
+                                required:
+                                  - object_type
+                            relation:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: object relation name
+                                required:
+                                  - relation
+                            subject_id:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: subject identifier
+                                required:
+                                  - subject_id
+                            subject_relation:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: optional subject relation name
+                            subject_type:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: subject type
+                                required:
+                                  - subject_type
+                            updated_at:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: last updated timestamp (UTC)
+                                format: date-time
+                                readOnly: true
+        default:
+          ref: ""
+          value:
+            extensionprops: {}
+            description: An unexpected error response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/rpcStatus'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      code:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: integer
+                          format: int32
+                      details:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          items:
+                            ref: '#/components/schemas/protobufAny'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              properties:
+                                type_url:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                value:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    format: byte
+                      message:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: string
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+  /api/v3/directory/relations:
+    extensionprops: {}
+    get:
+      extensionprops: {}
+      tags:
+        - directory
+      summary: List relations instances
+      description: Returns list of relation instances.
+      operationId: directory.v3.relations.list
+      parameters:
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: object_type
+            in: query
+            description: object type.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: object_id
+            in: query
+            description: object identifier.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: relation
+            in: query
+            description: relation name.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: subject_type
+            in: query
+            description: subject type.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: subject_id
+            in: query
+            description: subject identifier.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: subject_relation
+            in: query
+            description: optional subject relation name.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: with_objects
+            in: query
+            description: materialize relation objects.
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: boolean
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: page.size
+            in: query
+            description: requested page size, valid value between 1-100 rows (default 100).
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: integer
+                format: int32
+        - ref: ""
+          value:
+            extensionprops: {}
+            name: page.token
+            in: query
+            description: pagination start token, default "".
+            schema:
+              ref: ""
+              value:
+                extensionprops: {}
+                type: string
+      responses:
+        "200":
+          ref: ""
+          value:
+            extensionprops: {}
+            description: A successful response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/v3GetRelationsResponse'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      objects:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: object
+                          title: map of materialized relation objects
+                      page:
+                        ref: '#/components/schemas/v3PaginationResponse'
+                        value:
+                          extensionprops: {}
+                          type: object
+                          title: Pagination response
+                          properties:
+                            next_token:
+                              ref: ""
+                              value:
+                                extensionprops: {}
+                                type: string
+                                title: next page token, when empty there are no more pages to fetch
+                                readOnly: true
+                      results:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          title: array of relation instances
+                          items:
+                            ref: '#/components/schemas/v3Relation'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              required:
+                                - object_type
+                                - object_id
+                                - relation
+                                - subject_type
+                                - subject_id
+                              properties:
+                                created_at:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: created at timestamp (UTC)
+                                    format: date-time
+                                    readOnly: true
+                                etag:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: object instance etag
+                                object_id:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: object identifier
+                                    required:
+                                      - object_id
+                                object_type:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: object type
+                                    required:
+                                      - object_type
+                                relation:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: object relation name
+                                    required:
+                                      - relation
+                                subject_id:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: subject identifier
+                                    required:
+                                      - subject_id
+                                subject_relation:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: optional subject relation name
+                                subject_type:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: subject type
+                                    required:
+                                      - subject_type
+                                updated_at:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    title: last updated timestamp (UTC)
+                                    format: date-time
+                                    readOnly: true
+        default:
+          ref: ""
+          value:
+            extensionprops: {}
+            description: An unexpected error response.
+            content:
+              application/json:
+                extensionprops: {}
+                schema:
+                  ref: '#/components/schemas/rpcStatus'
+                  value:
+                    extensionprops: {}
+                    type: object
+                    properties:
+                      code:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: integer
+                          format: int32
+                      details:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: array
+                          items:
+                            ref: '#/components/schemas/protobufAny'
+                            value:
+                              extensionprops: {}
+                              type: object
+                              properties:
+                                type_url:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                value:
+                                  ref: ""
+                                  value:
+                                    extensionprops: {}
+                                    type: string
+                                    format: byte
+                      message:
+                        ref: ""
+                        value:
+                          extensionprops: {}
+                          type: string
+      security:
+        - DirectoryAPIKey: []
+          TenantID: []
+security:
+  - DirectoryAPIKey: []
+    TenantID: []
 servers:
   - extensionprops: {}
     url: https://directory.prod.aserto.com

--- a/service/directory/openapi.json
+++ b/service/directory/openapi.json
@@ -41,7 +41,58 @@
       },
       "type": "object"
     },
-    "v2CheckPermissionResponse": {
+    "v3CheckPermissionRequest": {
+      "properties": {
+        "object_id": {
+          "required": [
+            "object_id"
+          ],
+          "title": "object identifier",
+          "type": "string"
+        },
+        "object_type": {
+          "required": [
+            "object_type"
+          ],
+          "title": "object type",
+          "type": "string"
+        },
+        "permission": {
+          "required": [
+            "permission"
+          ],
+          "title": "permission name",
+          "type": "string"
+        },
+        "subject_id": {
+          "required": [
+            "subject_id"
+          ],
+          "title": "subject identifier",
+          "type": "string"
+        },
+        "subject_type": {
+          "required": [
+            "subject_type"
+          ],
+          "title": "subject type",
+          "type": "string"
+        },
+        "trace": {
+          "title": "collect trace information",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "object_type",
+        "object_id",
+        "permission",
+        "subject_type",
+        "subject_id"
+      ],
+      "type": "object"
+    },
+    "v3CheckPermissionResponse": {
       "properties": {
         "check": {
           "title": "check result",
@@ -57,7 +108,58 @@
       },
       "type": "object"
     },
-    "v2CheckRelationResponse": {
+    "v3CheckRelationRequest": {
+      "properties": {
+        "object_id": {
+          "required": [
+            "object_id"
+          ],
+          "title": "object identifier",
+          "type": "string"
+        },
+        "object_type": {
+          "required": [
+            "object_type"
+          ],
+          "title": "object type",
+          "type": "string"
+        },
+        "relation": {
+          "required": [
+            "relation"
+          ],
+          "title": "relation name",
+          "type": "string"
+        },
+        "subject_id": {
+          "required": [
+            "subject_id"
+          ],
+          "title": "subject identifier",
+          "type": "string"
+        },
+        "subject_type": {
+          "required": [
+            "subject_type"
+          ],
+          "title": "subject type",
+          "type": "string"
+        },
+        "trace": {
+          "title": "collect trace information",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "object_type",
+        "object_id",
+        "relation",
+        "subject_type",
+        "subject_id"
+      ],
+      "type": "object"
+    },
+    "v3CheckRelationResponse": {
       "properties": {
         "check": {
           "title": "check result",
@@ -73,7 +175,74 @@
       },
       "type": "object"
     },
-    "v2DeleteObjectResponse": {
+    "v3CheckRequest": {
+      "properties": {
+        "object_id": {
+          "required": [
+            "object_id"
+          ],
+          "title": "object identifier",
+          "type": "string"
+        },
+        "object_type": {
+          "required": [
+            "object_type"
+          ],
+          "title": "object type",
+          "type": "string"
+        },
+        "relation": {
+          "required": [
+            "relation"
+          ],
+          "title": "relation name",
+          "type": "string"
+        },
+        "subject_id": {
+          "required": [
+            "subject_id"
+          ],
+          "title": "subject identifier",
+          "type": "string"
+        },
+        "subject_type": {
+          "required": [
+            "subject_type"
+          ],
+          "title": "subject type",
+          "type": "string"
+        },
+        "trace": {
+          "title": "collect trace information",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "object_type",
+        "object_id",
+        "relation",
+        "subject_type",
+        "subject_id"
+      ],
+      "type": "object"
+    },
+    "v3CheckResponse": {
+      "properties": {
+        "check": {
+          "title": "check result",
+          "type": "boolean"
+        },
+        "trace": {
+          "items": {
+            "type": "string"
+          },
+          "title": "trace information",
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "v3DeleteObjectResponse": {
       "properties": {
         "result": {
           "properties": {},
@@ -82,7 +251,7 @@
       },
       "type": "object"
     },
-    "v2DeleteObjectTypeResponse": {
+    "v3DeleteRelationResponse": {
       "properties": {
         "result": {
           "properties": {},
@@ -91,38 +260,11 @@
       },
       "type": "object"
     },
-    "v2DeletePermissionResponse": {
-      "properties": {
-        "result": {
-          "properties": {},
-          "title": "empty result"
-        }
-      },
-      "type": "object"
-    },
-    "v2DeleteRelationResponse": {
-      "properties": {
-        "result": {
-          "properties": {},
-          "title": "empty result"
-        }
-      },
-      "type": "object"
-    },
-    "v2DeleteRelationTypeResponse": {
-      "properties": {
-        "result": {
-          "properties": {},
-          "title": "empty result"
-        }
-      },
-      "type": "object"
-    },
-    "v2GetGraphResponse": {
+    "v3GetGraphResponse": {
       "properties": {
         "results": {
           "items": {
-            "$ref": "#/definitions/v2ObjectDependency"
+            "$ref": "#/definitions/v3ObjectDependency"
           },
           "title": "dependency graph",
           "type": "array"
@@ -130,11 +272,11 @@
       },
       "type": "object"
     },
-    "v2GetObjectManyResponse": {
+    "v3GetObjectManyResponse": {
       "properties": {
         "results": {
           "items": {
-            "$ref": "#/definitions/v2Object"
+            "$ref": "#/definitions/v3Object"
           },
           "title": "array of object instances",
           "type": "array"
@@ -142,60 +284,35 @@
       },
       "type": "object"
     },
-    "v2GetObjectResponse": {
+    "v3GetObjectResponse": {
       "properties": {
         "page": {
-          "$ref": "#/definitions/v2PaginationResponse",
+          "$ref": "#/definitions/v3PaginationResponse",
           "title": "pagination response"
         },
         "relations": {
           "items": {
-            "$ref": "#/definitions/v2Relation"
+            "$ref": "#/definitions/v3Relation"
           },
           "title": "object relations",
           "type": "array"
         },
         "result": {
-          "$ref": "#/definitions/v2Object",
+          "$ref": "#/definitions/v3Object",
           "title": "object instance"
         }
       },
       "type": "object"
     },
-    "v2GetObjectTypeResponse": {
-      "properties": {
-        "result": {
-          "$ref": "#/definitions/v2ObjectType",
-          "title": "object type instance"
-        }
-      },
-      "type": "object"
-    },
-    "v2GetObjectTypesResponse": {
+    "v3GetObjectsResponse": {
       "properties": {
         "page": {
-          "$ref": "#/definitions/v2PaginationResponse",
+          "$ref": "#/definitions/v3PaginationResponse",
           "title": "pagination response"
         },
         "results": {
           "items": {
-            "$ref": "#/definitions/v2ObjectType"
-          },
-          "title": "array of object types",
-          "type": "array"
-        }
-      },
-      "type": "object"
-    },
-    "v2GetObjectsResponse": {
-      "properties": {
-        "page": {
-          "$ref": "#/definitions/v2PaginationResponse",
-          "title": "pagination response"
-        },
-        "results": {
-          "items": {
-            "$ref": "#/definitions/v2Object"
+            "$ref": "#/definitions/v3Object"
           },
           "title": "array of object instances",
           "type": "array"
@@ -203,84 +320,38 @@
       },
       "type": "object"
     },
-    "v2GetPermissionResponse": {
-      "properties": {
-        "result": {
-          "$ref": "#/definitions/v2Permission",
-          "title": "permission instance"
-        }
-      },
-      "type": "object"
-    },
-    "v2GetPermissionsResponse": {
-      "properties": {
-        "page": {
-          "$ref": "#/definitions/v2PaginationResponse",
-          "title": "pagination response"
-        },
-        "results": {
-          "items": {
-            "$ref": "#/definitions/v2Permission"
-          },
-          "title": "array of permissions",
-          "type": "array"
-        }
-      },
-      "type": "object"
-    },
-    "v2GetRelationResponse": {
+    "v3GetRelationResponse": {
       "properties": {
         "objects": {
           "additionalProperties": {
-            "$ref": "#/definitions/v2Object"
+            "$ref": "#/definitions/v3Object"
           },
           "title": "map of materialized relation objects",
           "type": "object"
         },
-        "results": {
-          "items": {
-            "$ref": "#/definitions/v2Relation"
-          },
-          "title": "array of relation instances",
-          "type": "array"
-        }
-      },
-      "type": "object"
-    },
-    "v2GetRelationTypeResponse": {
-      "properties": {
         "result": {
-          "$ref": "#/definitions/v2RelationType",
-          "title": "relation type instance"
+          "$ref": "#/definitions/v3Relation",
+          "title": "relation instance"
         }
       },
       "type": "object"
     },
-    "v2GetRelationTypesResponse": {
+    "v3GetRelationsResponse": {
       "properties": {
-        "page": {
-          "$ref": "#/definitions/v2PaginationResponse",
-          "title": "pagination response"
-        },
-        "results": {
-          "items": {
-            "$ref": "#/definitions/v2RelationType"
+        "objects": {
+          "additionalProperties": {
+            "$ref": "#/definitions/v3Object"
           },
-          "title": "array of relation types",
-          "type": "array"
-        }
-      },
-      "type": "object"
-    },
-    "v2GetRelationsResponse": {
-      "properties": {
+          "title": "map of materialized relation objects",
+          "type": "object"
+        },
         "page": {
-          "$ref": "#/definitions/v2PaginationResponse",
+          "$ref": "#/definitions/v3PaginationResponse",
           "title": "pagination response"
         },
         "results": {
           "items": {
-            "$ref": "#/definitions/v2Relation"
+            "$ref": "#/definitions/v3Relation"
           },
           "title": "array of relation instances",
           "type": "array"
@@ -288,10 +359,11 @@
       },
       "type": "object"
     },
-    "v2Object": {
+    "v3Object": {
       "properties": {
         "created_at": {
           "format": "date-time",
+          "readOnly": true,
           "title": "created at timestamp (UTC)",
           "type": "string"
         },
@@ -299,12 +371,15 @@
           "title": "display name object",
           "type": "string"
         },
-        "hash": {
-          "title": "object instance hash",
+        "etag": {
+          "title": "object instance etag",
           "type": "string"
         },
-        "key": {
-          "title": "external object key (cs-string)",
+        "id": {
+          "required": [
+            "id"
+          ],
+          "title": "external object identifier (cs-string, no spaces or tabs)",
           "type": "string"
         },
         "properties": {
@@ -312,128 +387,104 @@
           "type": "object"
         },
         "type": {
+          "required": [
+            "type"
+          ],
           "title": "object type name",
           "type": "string"
         },
         "updated_at": {
           "format": "date-time",
+          "readOnly": true,
           "title": "last updated timestamp (UTC)",
           "type": "string"
         }
       },
+      "required": [
+        "type",
+        "id"
+      ],
       "type": "object"
     },
-    "v2ObjectDependency": {
+    "v3ObjectDependency": {
       "properties": {
         "depth": {
           "format": "int32",
+          "readOnly": true,
           "title": "dependency depth",
           "type": "integer"
         },
         "is_cycle": {
+          "readOnly": true,
           "title": "dependency cycle",
           "type": "boolean"
         },
-        "object_key": {
-          "title": "object search key of source object",
+        "object_id": {
+          "readOnly": true,
+          "title": "object identifier",
           "type": "string"
         },
         "object_type": {
-          "title": "object type name of source object",
+          "readOnly": true,
+          "title": "object type",
           "type": "string"
         },
         "path": {
           "items": {
             "type": "string"
           },
+          "readOnly": true,
           "title": "dependency path",
           "type": "array"
         },
         "relation": {
-          "title": "relation identifier",
+          "readOnly": true,
+          "title": "object relation name",
           "type": "string"
         },
-        "subject_key": {
-          "title": "object search key of target object",
+        "subject_id": {
+          "readOnly": true,
+          "title": "subject identifier",
+          "type": "string"
+        },
+        "subject_relation": {
+          "readOnly": true,
+          "title": "optional subject relation name",
           "type": "string"
         },
         "subject_type": {
-          "title": "object type id of target object",
+          "readOnly": true,
+          "title": "subject type",
           "type": "string"
         }
       },
       "type": "object"
     },
-    "v2ObjectIdentifier": {
+    "v3ObjectIdentifier": {
       "properties": {
-        "key": {
-          "title": "external object key (cs-string)",
+        "object_id": {
+          "required": [
+            "object_id"
+          ],
+          "title": "object identifier (cs-string)",
           "type": "string"
         },
-        "type": {
-          "title": "object type",
+        "object_type": {
+          "required": [
+            "object_type"
+          ],
+          "title": "object type (lc-string)",
           "type": "string"
         }
       },
+      "required": [
+        "object_type",
+        "object_id"
+      ],
       "title": "Object identifier",
       "type": "object"
     },
-    "v2ObjectType": {
-      "properties": {
-        "created_at": {
-          "format": "date-time",
-          "title": "created at timestamp (UTC)",
-          "type": "string"
-        },
-        "display_name": {
-          "title": "object type display name",
-          "type": "string"
-        },
-        "hash": {
-          "title": "object instance hash",
-          "type": "string"
-        },
-        "is_subject": {
-          "title": "object type is a subject (user|group) (default false)",
-          "type": "boolean"
-        },
-        "name": {
-          "title": "object type name (unique, lc-string)",
-          "type": "string"
-        },
-        "ordinal": {
-          "format": "int32",
-          "title": "sort ordinal (default 0)",
-          "type": "integer"
-        },
-        "schema": {
-          "title": "object type schema definition (JSON)",
-          "type": "object"
-        },
-        "status": {
-          "format": "int64",
-          "title": "status flag bitmap (default 0)",
-          "type": "integer"
-        },
-        "updated_at": {
-          "format": "date-time",
-          "title": "last updated timestamp (UTC)",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "v2ObjectTypeIdentifier": {
-      "properties": {
-        "name": {
-          "title": "object type name (unique, lc-string)",
-          "type": "string"
-        }
-      },
-      "title": "ObjectType identifier",
-      "type": "object"
-    },
-    "v2PaginationRequest": {
+    "v3PaginationRequest": {
       "properties": {
         "size": {
           "format": "int32",
@@ -448,230 +499,874 @@
       "title": "Pagination request",
       "type": "object"
     },
-    "v2PaginationResponse": {
+    "v3PaginationResponse": {
       "properties": {
         "next_token": {
+          "readOnly": true,
           "title": "next page token, when empty there are no more pages to fetch",
           "type": "string"
-        },
-        "result_size": {
-          "format": "int32",
-          "title": "result size of the page returned",
-          "type": "integer"
         }
       },
       "title": "Pagination response",
       "type": "object"
     },
-    "v2Permission": {
+    "v3Relation": {
       "properties": {
         "created_at": {
           "format": "date-time",
+          "readOnly": true,
           "title": "created at timestamp (UTC)",
           "type": "string"
         },
-        "display_name": {
-          "title": "permission display name",
+        "etag": {
+          "title": "object instance etag",
           "type": "string"
         },
-        "hash": {
-          "title": "object instance hash",
-          "type": "string"
-        },
-        "name": {
-          "title": "permission name (unique, cs-string)",
-          "type": "string"
-        },
-        "updated_at": {
-          "format": "date-time",
-          "title": "last updated timestamp (UTC)",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "v2PermissionIdentifier": {
-      "properties": {
-        "name": {
-          "title": "permission name (unique, cs-string)",
-          "type": "string"
-        }
-      },
-      "title": "Permission identifier",
-      "type": "object"
-    },
-    "v2Relation": {
-      "properties": {
-        "created_at": {
-          "format": "date-time",
-          "title": "created at timestamp (UTC)",
-          "type": "string"
-        },
-        "hash": {
-          "title": "object instance hash",
-          "type": "string"
-        },
-        "object": {
-          "$ref": "#/definitions/v2ObjectIdentifier",
-          "title": "object identifier"
-        },
-        "relation": {
-          "title": "relation type name",
-          "type": "string"
-        },
-        "subject": {
-          "$ref": "#/definitions/v2ObjectIdentifier",
-          "title": "subject identifier"
-        },
-        "updated_at": {
-          "format": "date-time",
-          "title": "last updated timestamp (UTC)",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "v2RelationIdentifier": {
-      "properties": {
-        "object": {
-          "$ref": "#/definitions/v2ObjectIdentifier",
-          "title": "object identifier"
-        },
-        "relation": {
-          "$ref": "#/definitions/v2RelationTypeIdentifier",
-          "title": "relation identifier"
-        },
-        "subject": {
-          "$ref": "#/definitions/v2ObjectIdentifier",
-          "title": "subject identifier"
-        }
-      },
-      "title": "Relation identifier",
-      "type": "object"
-    },
-    "v2RelationType": {
-      "properties": {
-        "created_at": {
-          "format": "date-time",
-          "title": "created at timestamp (UTC)",
-          "type": "string"
-        },
-        "display_name": {
-          "title": "relation display name",
-          "type": "string"
-        },
-        "hash": {
-          "title": "object instance hash",
-          "type": "string"
-        },
-        "name": {
-          "title": "relation type name selector",
+        "object_id": {
+          "required": [
+            "object_id"
+          ],
+          "title": "object identifier",
           "type": "string"
         },
         "object_type": {
-          "title": "object type referenced by relation",
+          "required": [
+            "object_type"
+          ],
+          "title": "object type",
           "type": "string"
         },
-        "ordinal": {
-          "format": "int32",
-          "title": "sort ordinal (default 0)",
-          "type": "integer"
+        "relation": {
+          "required": [
+            "relation"
+          ],
+          "title": "object relation name",
+          "type": "string"
         },
-        "permissions": {
-          "items": {
-            "type": "string"
-          },
-          "title": "permissions associated to relation type instance",
-          "type": "array"
+        "subject_id": {
+          "required": [
+            "subject_id"
+          ],
+          "title": "subject identifier",
+          "type": "string"
         },
-        "status": {
-          "format": "int64",
-          "title": "status bitmap (default 0)",
-          "type": "integer"
+        "subject_relation": {
+          "title": "optional subject relation name",
+          "type": "string"
         },
-        "unions": {
-          "items": {
-            "type": "string"
-          },
-          "title": "relations union-ed with relation type instance",
-          "type": "array"
+        "subject_type": {
+          "required": [
+            "subject_type"
+          ],
+          "title": "subject type",
+          "type": "string"
         },
         "updated_at": {
           "format": "date-time",
+          "readOnly": true,
           "title": "last updated timestamp (UTC)",
           "type": "string"
         }
       },
+      "required": [
+        "object_type",
+        "object_id",
+        "relation",
+        "subject_type",
+        "subject_id"
+      ],
       "type": "object"
     },
-    "v2RelationTypeIdentifier": {
+    "v3SetObjectRequest": {
       "properties": {
-        "name": {
-          "title": "relation type name selector",
-          "type": "string"
-        },
-        "object_type": {
-          "title": "object type referenced by relation",
-          "type": "string"
-        }
-      },
-      "title": "RelationType identifier",
-      "type": "object"
-    },
-    "v2SetObjectResponse": {
-      "properties": {
-        "result": {
-          "$ref": "#/definitions/v2Object",
+        "object": {
+          "$ref": "#/definitions/v3Object",
           "title": "object instance"
         }
       },
       "type": "object"
     },
-    "v2SetObjectTypeResponse": {
+    "v3SetObjectResponse": {
       "properties": {
         "result": {
-          "$ref": "#/definitions/v2ObjectType",
-          "title": "object type instance"
+          "$ref": "#/definitions/v3Object",
+          "title": "object instance"
         }
       },
       "type": "object"
     },
-    "v2SetPermissionResponse": {
+    "v3SetRelationRequest": {
       "properties": {
-        "result": {
-          "$ref": "#/definitions/v2Permission",
-          "title": "permission instance"
-        }
-      },
-      "type": "object"
-    },
-    "v2SetRelationResponse": {
-      "properties": {
-        "result": {
-          "$ref": "#/definitions/v2Relation",
+        "relation": {
+          "$ref": "#/definitions/v3Relation",
           "title": "relation instance"
         }
       },
       "type": "object"
     },
-    "v2SetRelationTypeResponse": {
+    "v3SetRelationResponse": {
       "properties": {
         "result": {
-          "$ref": "#/definitions/v2RelationType",
-          "title": "relation types instance"
+          "$ref": "#/definitions/v3Relation",
+          "title": "relation instance"
         }
       },
       "type": "object"
     }
   },
+  "externalDocs": {
+    "description": "Aserto API Reference.",
+    "url": "https://docs.aserto.com"
+  },
   "info": {
-    "title": "aserto/directory/common/v2/common.proto",
+    "contact": {
+      "email": "support@aserto.com",
+      "name": "Aserto, Inc.",
+      "url": "https://github.com/aserto-dev/pb-directory"
+    },
+    "license": {
+      "name": "Apache 2.0 License",
+      "url": "https://github.com/aserto-dev/pb-directory/blob/main/LICENSE"
+    },
+    "title": "aserto/directory/common/v3/common.proto",
     "version": "version not set"
   },
-  "paths": {},
+  "paths": {
+    "/api/v3/directory/check": {
+      "post": {
+        "description": "Returns check outcome.",
+        "operationId": "directory.v3.check",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v3CheckRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3CheckResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Check",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/check/permission": {
+      "post": {
+        "description": "Returns check permission outcome.",
+        "operationId": "directory.v3.check.permission",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v3CheckPermissionRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3CheckPermissionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Check permission",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/check/relation": {
+      "post": {
+        "description": "Returns check relation outcome.",
+        "operationId": "directory.v3.check.relation",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v3CheckRelationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3CheckRelationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Check relation",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/graph/{anchor_type}/{anchor_id}": {
+      "get": {
+        "description": "Returns object graph from anchor to subject or object.",
+        "operationId": "directory.v3.graph",
+        "parameters": [
+          {
+            "description": "anchor type",
+            "in": "path",
+            "name": "anchor_type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "anchor identifier",
+            "in": "path",
+            "name": "anchor_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "object type.",
+            "in": "query",
+            "name": "object_type",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "object identifier.",
+            "in": "query",
+            "name": "object_id",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "relation name.",
+            "in": "query",
+            "name": "relation",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "subject type.",
+            "in": "query",
+            "name": "subject_type",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "subject identifier.",
+            "in": "query",
+            "name": "subject_id",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "subject relation.",
+            "in": "query",
+            "name": "subject_relation",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3GetGraphResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Get graph",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/object": {
+      "post": {
+        "description": "Set object.",
+        "operationId": "directory.v3.object.set",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v3SetObjectRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3SetObjectResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Set object",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/object/{object_type}/{object_id}": {
+      "delete": {
+        "description": "Delete object.",
+        "operationId": "directory.v3.object.delete",
+        "parameters": [
+          {
+            "description": "object type",
+            "in": "path",
+            "name": "object_type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "object identifier",
+            "in": "path",
+            "name": "object_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "delete object relations, both object and subject relations.",
+            "in": "query",
+            "name": "with_relations",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3DeleteObjectResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Delete object",
+        "tags": [
+          "directory"
+        ]
+      },
+      "get": {
+        "description": "Returns single object instance, optionally with relations.",
+        "operationId": "directory.v3.object.get",
+        "parameters": [
+          {
+            "description": "object type name (lc-string)",
+            "in": "path",
+            "name": "object_type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "object identifier (cs-string)",
+            "in": "path",
+            "name": "object_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "materialize the object relations objects.",
+            "in": "query",
+            "name": "with_relations",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "description": "requested page size, valid value between 1-100 rows (default 100).",
+            "format": "int32",
+            "in": "query",
+            "name": "page.size",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "description": "pagination start token, default \"\".",
+            "in": "query",
+            "name": "page.token",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3GetObjectResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Get object instance",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/objects": {
+      "get": {
+        "description": "Returns list of object instances.",
+        "operationId": "directory.v3.objects.list",
+        "parameters": [
+          {
+            "description": "object type name (lc-string).",
+            "in": "query",
+            "name": "object_type",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "requested page size, valid value between 1-100 rows (default 100).",
+            "format": "int32",
+            "in": "query",
+            "name": "page.size",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "description": "pagination start token, default \"\".",
+            "in": "query",
+            "name": "page.token",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3GetObjectsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "List object instances",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/relation": {
+      "delete": {
+        "description": "Delete relation.",
+        "operationId": "directory.v3.relation.delete",
+        "parameters": [
+          {
+            "description": "object type.",
+            "in": "query",
+            "name": "object_type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "object identifier.",
+            "in": "query",
+            "name": "object_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "object relation name.",
+            "in": "query",
+            "name": "relation",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "subject type.",
+            "in": "query",
+            "name": "subject_type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "subject identifier.",
+            "in": "query",
+            "name": "subject_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "optional subject relation name.",
+            "in": "query",
+            "name": "subject_relation",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3DeleteRelationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Delete relation",
+        "tags": [
+          "directory"
+        ]
+      },
+      "get": {
+        "description": "Returns single relation instance, optionally with objects.",
+        "operationId": "directory.v3.relation.get",
+        "parameters": [
+          {
+            "description": "object type.",
+            "in": "query",
+            "name": "object_type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "object identifier.",
+            "in": "query",
+            "name": "object_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "relation name.",
+            "in": "query",
+            "name": "relation",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "subject type.",
+            "in": "query",
+            "name": "subject_type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "subject identifier.",
+            "in": "query",
+            "name": "subject_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "optional subject relation name.",
+            "in": "query",
+            "name": "subject_relation",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "materialize relation objects.",
+            "in": "query",
+            "name": "with_objects",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3GetRelationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Get relation instance",
+        "tags": [
+          "directory"
+        ]
+      },
+      "post": {
+        "description": "Set relation.",
+        "operationId": "directory.v3.relation.set",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v3SetRelationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3SetRelationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "Set relation",
+        "tags": [
+          "directory"
+        ]
+      }
+    },
+    "/api/v3/directory/relations": {
+      "get": {
+        "description": "Returns list of relation instances.",
+        "operationId": "directory.v3.relations.list",
+        "parameters": [
+          {
+            "description": "object type.",
+            "in": "query",
+            "name": "object_type",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "object identifier.",
+            "in": "query",
+            "name": "object_id",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "relation name.",
+            "in": "query",
+            "name": "relation",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "subject type.",
+            "in": "query",
+            "name": "subject_type",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "subject identifier.",
+            "in": "query",
+            "name": "subject_id",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "optional subject relation name.",
+            "in": "query",
+            "name": "subject_relation",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "materialize relation objects.",
+            "in": "query",
+            "name": "with_objects",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "description": "requested page size, valid value between 1-100 rows (default 100).",
+            "format": "int32",
+            "in": "query",
+            "name": "page.size",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "description": "pagination start token, default \"\".",
+            "in": "query",
+            "name": "page.token",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v3GetRelationsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "security": [
+          {
+            "DirectoryAPIKey": [],
+            "TenantID": []
+          }
+        ],
+        "summary": "List relations instances",
+        "tags": [
+          "directory"
+        ]
+      }
+    }
+  },
   "produces": [
     "application/json"
   ],
+  "schemes": [
+    "http",
+    "https",
+    "wss"
+  ],
+  "security": [
+    {
+      "DirectoryAPIKey": [],
+      "TenantID": []
+    }
+  ],
+  "securityDefinitions": {
+    "DirectoryAPIKey": {
+      "in": "header",
+      "name": "authorization",
+      "type": "apiKey"
+    },
+    "TenantID": {
+      "in": "header",
+      "name": "aserto-tenant-id",
+      "type": "apiKey"
+    }
+  },
   "swagger": "2.0",
   "tags": [
     {


### PR DESCRIPTION
Even though we have v3 service definitions generated from pb-directory, we were building the OpenAPI spec from the v2 ones 🤦 