### PR TITLE
Publish to readme.io on tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Read Configuration
-      uses: hashicorp/vault-action@v2.5.0
+      uses: hashicorp/vault-action@v3
       id: vault
       with:
         url: ${{ env.VAULT_ADDR }}
@@ -35,12 +35,12 @@ jobs:
           kv/data/github  "READ_WRITE_TOKEN"    | READ_WRITE_TOKEN;
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Setup Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
 
@@ -71,3 +71,26 @@ jobs:
       uses: EndBug/add-and-commit@v9
       with:
         default_author: github_actions
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Read Configuration
+        uses: hashicorp/vault-action@3
+        id: vault
+        with:
+          url: ${{ env.VAULT_ADDR }}
+          token: ${{ secrets.VAULT_TOKEN }}
+          secrets: |
+            kv/data/readme  "README_OAS_DIRECTORY_KEY"     | README_OAS_DIRECTORY_KEY;
+            kv/data/readme  "DIRECTORY_API_DEFINITION_ID"  | DIRECTORY_API_DEFINITION_ID;
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Publish to readme.io
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi ./publish/directory/openapi.json --key=${{ stepa.vault.outputs.README_OAS_DIRECTORY_KEY }} --id ${{ steps.vault.outputs.DIRECTORY_API_DEFINITION_ID }}


### PR DESCRIPTION
Use the `readmeio/rdme@v8` action to publish the OpenAPI spec to readme.io on tags.