### PR TITLE
Commit changes as GH App

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,17 +55,6 @@ jobs:
       -
         name: Install dependencies
         run: |
-            mkdir -p $HOME/.ssh
-            umask 0077 && echo -e "${SSH_PRIVATE_KEY}" > $HOME/.ssh/id_rsa
-            ssh-keyscan github.com >> $HOME/.ssh/known_hosts
-
-            git config --global url."git@github.com:".insteadOf https://github.com/
-            git config --global user.email "github-bot@aserto.com"
-            git config --global user.name "Aserto Bot"
-
-            eval `ssh-agent`
-            ssh-add $HOME/.ssh/id_rsa
-
             go run mage.go deps
       -
         name: Clean generated code


### PR DESCRIPTION
Do not use the aserto-bot SSH token to commit changes. Only the aserto-codegen GitHub app has permission to bypass branch protection rules.