### PR TITLE
Add service name to stream operation ids

### DIFF
--- a/aserto/directory/model/v3/model.ext.openapi.json
+++ b/aserto/directory/model/v3/model.ext.openapi.json
@@ -8,7 +8,7 @@
         ],
         "summary": "Get manifest",
         "description": "Get manifest.",
-        "operationId": "directory.v3.manifest.get",
+        "operationId": "directory.model.v3.manifest.get",
         "parameters": [
           {
             "name": "If-None-Match",
@@ -22,7 +22,9 @@
                 },
                 {
                   "type": "array",
-                  "items": {"type": "string"}
+                  "items": {
+                    "type": "string"
+                  }
                 }
               ]
             }
@@ -97,7 +99,7 @@
         ],
         "summary": "Get manifest metadata",
         "description": "Get manifest metadata.",
-        "operationId": "directory.v3.manifest.get_metadata",
+        "operationId": "directory.model.v3.manifest.get_metadata",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -141,7 +143,7 @@
         ],
         "summary": "Set manifest",
         "description": "Set manifest.",
-        "operationId": "directory.v3.manifest.set",
+        "operationId": "directory.model.v3.manifest.set",
         "requestBody": {
           "description": "Manifest YAML file",
           "required": true,
@@ -200,4 +202,3 @@
     }
   }
 }
-

--- a/aserto/directory/reader/v3/reader.swagger.json
+++ b/aserto/directory/reader/v3/reader.swagger.json
@@ -88,6 +88,7 @@
         "tags": [
           "directory"
         ],
+        "deprecated": true,
         "security": [
           {
             "DirectoryAPIKey": [],
@@ -128,6 +129,7 @@
         "tags": [
           "directory"
         ],
+        "deprecated": true,
         "security": [
           {
             "DirectoryAPIKey": [],

--- a/buf/buf.gen.yaml
+++ b/buf/buf.gen.yaml
@@ -7,3 +7,4 @@ plugins:
       - json_names_for_fields=false  # use proto names.
       - allow_delete_body=true       # DELETE requests may have a body.
       - simple_operation_ids=true    # Remove service prefix from operation IDs.
+      - enable_rpc_deprecation=true  # process grpc method's deprecated options.

--- a/publish/directory/openapi.json
+++ b/publish/directory/openapi.json
@@ -793,7 +793,7 @@
     },
     "termsOfService": "https://aserto.com/terms/",
     "title": "Directory",
-    "version": "v0.33.2"
+    "version": "v0.33.3"
   },
   "openapi": "3.0.3",
   "paths": {
@@ -1353,7 +1353,7 @@
       },
       "get": {
         "description": "Get manifest.",
-        "operationId": "directory.v3.manifest.get",
+        "operationId": "directory.model.v3.manifest.get",
         "parameters": [
           {
             "description": "When If-None-Match is set, and includes the currnet manifest etag, the response is 304 Not Modified.",
@@ -1443,7 +1443,7 @@
       },
       "head": {
         "description": "Get manifest metadata.",
-        "operationId": "directory.v3.manifest.get_metadata",
+        "operationId": "directory.model.v3.manifest.get_metadata",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1487,7 +1487,7 @@
       },
       "post": {
         "description": "Set manifest.",
-        "operationId": "directory.v3.manifest.set",
+        "operationId": "directory.model.v3.manifest.set",
         "parameters": [
           {
             "description": "When If-Match is set, and different from the current manifest etag, the response is 412 Precondition Failed.",

--- a/publish/directory/openapi.json
+++ b/publish/directory/openapi.json
@@ -1052,6 +1052,7 @@
     },
     "/api/v3/directory/check/permission": {
       "post": {
+        "deprecated": true,
         "description": "Returns check permission outcome.",
         "operationId": "directory.reader.v3.check.permission",
         "requestBody": {
@@ -1101,6 +1102,7 @@
     },
     "/api/v3/directory/check/relation": {
       "post": {
+        "deprecated": true,
         "description": "Returns check relation outcome.",
         "operationId": "directory.reader.v3.check.relation",
         "requestBody": {

--- a/publish/directory/openapi.yaml
+++ b/publish/directory/openapi.yaml
@@ -564,7 +564,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   termsOfService: https://aserto.com/terms/
   title: Directory
-  version: v0.33.2
+  version: v0.33.3
 openapi: 3.0.3
 paths:
   /api/v3/directory/assertion:
@@ -911,7 +911,7 @@ paths:
         - directory
     get:
       description: Get manifest.
-      operationId: directory.v3.manifest.get
+      operationId: directory.model.v3.manifest.get
       parameters:
         - description: When If-None-Match is set, and includes the currnet manifest etag, the response is 304 Not Modified.
           in: header
@@ -966,7 +966,7 @@ paths:
         - directory
     head:
       description: Get manifest metadata.
-      operationId: directory.v3.manifest.get_metadata
+      operationId: directory.model.v3.manifest.get_metadata
       responses:
         "200":
           description: A successful response.
@@ -994,7 +994,7 @@ paths:
         - directory
     post:
       description: Set manifest.
-      operationId: directory.v3.manifest.set
+      operationId: directory.model.v3.manifest.set
       parameters:
         - description: When If-Match is set, and different from the current manifest etag, the response is 412 Precondition Failed.
           in: header

--- a/publish/directory/openapi.yaml
+++ b/publish/directory/openapi.yaml
@@ -725,6 +725,7 @@ paths:
         - directory
   /api/v3/directory/check/permission:
     post:
+      deprecated: true
       description: Returns check permission outcome.
       operationId: directory.reader.v3.check.permission
       requestBody:
@@ -755,6 +756,7 @@ paths:
         - directory
   /api/v3/directory/check/relation:
     post:
+      deprecated: true
       description: Returns check relation outcome.
       operationId: directory.reader.v3.check.relation
       requestBody:

--- a/service/directory/openapi.json
+++ b/service/directory/openapi.json
@@ -1024,6 +1024,7 @@
     },
     "/api/v3/directory/check/permission": {
       "post": {
+        "deprecated": true,
         "description": "Returns check permission outcome.",
         "operationId": "directory.reader.v3.check.permission",
         "parameters": [
@@ -1064,6 +1065,7 @@
     },
     "/api/v3/directory/check/relation": {
       "post": {
+        "deprecated": true,
         "description": "Returns check relation outcome.",
         "operationId": "directory.reader.v3.check.relation",
         "parameters": [


### PR DESCRIPTION
Those aren't generated from protobuf and injected during the build.

Also add `enable_rpc_deprecation` to include deprecation notices.